### PR TITLE
Correct path to test HTML file in index-template.js

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ Cerner Corporation
 - Matt Butler [@matt-butler]
 - Rory Hardy [@gneatgeek]
 - Tao Zhang [@windse7en]
+- Mark Cummings [@codeweevil]
 
 
 
@@ -13,3 +14,4 @@ Cerner Corporation
 [@matt-butler]: https://github.com/matt-butler
 [@gneatgeek]: https://github.com/gneatgeek
 [@windse7en]:https://github.com/windse7en
+[@codeweevil]:https://github.com/codeweevil

--- a/src/index-template.ejs
+++ b/src/index-template.ejs
@@ -1,1 +1,1 @@
-<%= require('html!../tests/visual/terra/application/terra-application.html') %>
+<%= require('html!../tests/visual/terra-application.html') %>


### PR DESCRIPTION
### Summary
Fixed broken path in `src/index-template.js`, which was causing `npm start` to fail.

