### PR TITLE
Reference lib not src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Fixed
+* terra-dev-site doc to reference lib folder.
 
 1.14.0 - (November 21, 2019)
 ------------------

--- a/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationBase.doc.mdx
+++ b/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationBase.doc.mdx
@@ -1,4 +1,4 @@
-import PropsTable from 'terra-application/src/application-base/ApplicationBase?dev-site-props-table';
+import PropsTable from 'terra-application/lib/application-base/ApplicationBase?dev-site-props-table';
 
 # ApplicationBase
 

--- a/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationErrorBoundary.doc.mdx
+++ b/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationErrorBoundary.doc.mdx
@@ -1,5 +1,5 @@
-import PropsTable from 'terra-application/src/application-error-boundary/ApplicationErrorBoundary?dev-site-props-table';
-import ApplicationErrorBoundaryExample from 'terra-application/src/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationErrorBoundaryExample?dev-site-example';
+import PropsTable from 'terra-application/lib/application-error-boundary/ApplicationErrorBoundary?dev-site-props-table';
+import ApplicationErrorBoundaryExample from 'terra-application/lib/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationErrorBoundaryExample?dev-site-example';
 
 # ApplicationErrorBoundary
 

--- a/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationLoadingOverlay.doc.mdx
+++ b/src/terra-dev-site/doc/terra-application/reference.1/components/ApplicationLoadingOverlay.doc.mdx
@@ -1,10 +1,10 @@
-import ApplicationLoadingOverlayProps from 'terra-application/src/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationLoadingOverlayProps?dev-site-props-table';
-import ApplicationLoadingOverlayProviderProps from 'terra-application/src/application-loading-overlay/ApplicationLoadingOverlayProvider?dev-site-props-table';
-import ApplicationLoadingOverlayExample from 'terra-application/src/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationLoadingOverlayExample?dev-site-example';
+import ApplicationLoadingOverlayProps from 'terra-application/lib/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationLoadingOverlayProps?dev-site-props-table';
+import ApplicationLoadingOverlayProviderProps from 'terra-application/lib/application-loading-overlay/ApplicationLoadingOverlayProvider?dev-site-props-table';
+import ApplicationLoadingOverlayExample from 'terra-application/lib/terra-dev-site/doc/terra-application/reference.1/components/example/ApplicationLoadingOverlayExample?dev-site-example';
 
 # ApplicationLoadingOverlay
 
-The ApplicationLoadingOverlay is used to render loading overlays within the application. 
+The ApplicationLoadingOverlay is used to render loading overlays within the application.
 
 ## Usage
 
@@ -18,7 +18,7 @@ import ApplicationLoadingOverlay from 'terra-application/lib/application-loading
 
 # ApplicationLoadingOverlayProvider
 
-The ApplicationLoadingOverlayProvider defines a container within which loading overlays may be rendered. 
+The ApplicationLoadingOverlayProvider defines a container within which loading overlays may be rendered.
 
 Any ApplicationLoadingOverlay components rendered by children of the ApplicationLoadingOverlayProvider will result in the ApplicationLoadingOverlayProvider rendering a single loading overlay on top of its children. The style of the overlay will be determined by the `backgroundStyle` prop specified for each ApplicationLoadingOverlay, with the darkest specified style being honored.
 


### PR DESCRIPTION
### Summary
Some of the dev site docs reference src, not lib, this doesn't cause issue in this repo because the files will be transpiled by the webpack, but in terra-ui the files will not be transpiled because we do not transpile files within the node_modules folder.

### Additional Details

@cerner/terra

[CONTRIBUTORS.md]: https://github.com/cerner/terra-application/blob/master/CONTRIBUTORS.md
[License]: https://github.com/cerner/terra-application/blob/master/License.md
