### PR TITLE
Update terra-application-navigation dependency to be more optimistic

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
-    "terra-application-navigation": "1.11.0",
+    "terra-application-navigation": "^1.11.0",
     "terra-base": "^5.0.0",
     "terra-breakpoints": "^2.0.0",
     "terra-disclosure-manager": "^4.27.0",


### PR DESCRIPTION
### Summary

When the terra-application-navigation dependency was added to the package, it was locked into the most recent version. Let's be a little more optimistic about that package.