### PR TITLE
Providing Theme Context/Update theme provider.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ errorScreenshots
 stats.json
 aggregated-themes.js
 package-lock.json
+generated-themes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Unreleased
 ### Added
 * Added theme context to allow components to access the current theme.
 
+### Removed
+* As a part of updating theme provider the `themeIsGlobal` prop has been removed. While this traditionally would be considered non-passive, this prop was broken, removing it is considered a bug fix.
+
 1.18.0 - (March 24, 2020)
 ------------------
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 Unreleased
 ----------
+### Added
+* Added theme context to allow components to access the current theme.
 
 1.18.0 - (March 24, 2020)
 ------------------

--- a/dev-site-config/site.config.js
+++ b/dev-site-config/site.config.js
@@ -1,5 +1,13 @@
 const siteConfig = {
   includeTestEvidence: false,
+  appConfig: {
+
+    themes: {
+      'Default Theme': '',
+      'Clinical-lowlight-theme': 'clinical-lowlight-theme',
+      'Orion Fusion Theme': 'orion-fusion-theme',
+    },
+  },
 };
 
 module.exports = siteConfig;

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "terra-scroll": "^2.18.0",
     "terra-slide-panel-manager": "^5.19.0",
     "terra-status-view": "^4.10.0",
-    "terra-theme-provider": "^3.15.0",
+    "terra-theme-provider": "^4.0.0",
     "uuid": "^3.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "terra-application-navigation": "^1.11.0",
     "terra-base": "^5.0.0",
     "terra-breakpoints": "^2.0.0",
-    "terra-disclosure-manager": "^4.27.0",
     "terra-content-container": "^3.14.0",
+    "terra-disclosure-manager": "^4.27.0",
     "terra-doc-template": "^2.2.0",
     "terra-modal-manager": "^6.20.0",
     "terra-navigation-prompt": "^1.18.0",
@@ -111,6 +111,7 @@
     "terra-scroll": "^2.18.0",
     "terra-slide-panel-manager": "^5.19.0",
     "terra-status-view": "^4.10.0",
+    "terra-theme-context": "^1.0.0",
     "terra-theme-provider": "^4.0.0",
     "uuid": "^3.0.0"
   },

--- a/src/application-base/ApplicationBase.jsx
+++ b/src/application-base/ApplicationBase.jsx
@@ -1,9 +1,12 @@
-import React, { useRef, useEffect, Suspense } from 'react';
+import React, {
+  useRef, useEffect, Suspense, useMemo,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Base from 'terra-base';
 import ThemeProvider from 'terra-theme-provider';
 import { ActiveBreakpointProvider } from 'terra-breakpoints';
+// import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
 import ApplicationErrorBoundary from '../application-error-boundary';
 import ApplicationLoadingOverlay, { ApplicationLoadingOverlayProvider } from '../application-loading-overlay';
@@ -52,10 +55,6 @@ const propTypes = {
    */
   themeName: PropTypes.string,
   /**
-   * If provided, the theme styles are applied to the entire document.
-   */
-  themeIsGlobal: PropTypes.bool,
-  /**
    * By default, the elements rendered by ApplicationBase are fit to the Application's parent using 100% height.
    * If `fitToParentIsDisabled` is provided, the Application will render at its intrinsic content height and
    * overflow potentially overflow its parent.
@@ -100,36 +99,40 @@ const ApplicationBase = ({
     };
   }, [unloadPromptIsDisabled, registeredPromptsRef]);
 
+  const theme = useMemo(() => ({ className: themeName }), [themeName]);
+
   return (
-    <ThemeProvider
-      className={cx('application-theme-provider', { fill: !fitToParentIsDisabled })}
-      themeName={themeName}
-      isGlobalTheme={themeIsGlobal}
-    >
-      <Base
-        customMessages={customTranslatedMessages}
-        translationsLoadingPlaceholder={translationsLoadingPlaceholder}
-        locale={locale || browserLocale}
+    <div className={cx('application-base', { fill: !fitToParentIsDisabled })}>
+      <ThemeProvider
+        themeName={themeName}
       >
-        <ApplicationErrorBoundary>
-          <ApplicationIntlProvider>
-            <ActiveBreakpointProvider>
-              <NavigationPromptCheckpoint
-                onPromptChange={(registeredPrompts) => {
-                  registeredPromptsRef.current = registeredPrompts;
-                }}
-              >
-                <ApplicationLoadingOverlayProvider>
-                  <Suspense fallback={<ApplicationLoadingOverlay isOpen />}>
-                    {children}
-                  </Suspense>
-                </ApplicationLoadingOverlayProvider>
-              </NavigationPromptCheckpoint>
-            </ActiveBreakpointProvider>
-          </ApplicationIntlProvider>
-        </ApplicationErrorBoundary>
-      </Base>
-    </ThemeProvider>
+        {/* <ThemeContextProvider theme={theme}> */}
+          <Base
+            customMessages={customTranslatedMessages}
+            translationsLoadingPlaceholder={translationsLoadingPlaceholder}
+            locale={locale || browserLocale}
+          >
+            <ApplicationErrorBoundary>
+              <ApplicationIntlProvider>
+                <ActiveBreakpointProvider>
+                  <NavigationPromptCheckpoint
+                    onPromptChange={(registeredPrompts) => {
+                      registeredPromptsRef.current = registeredPrompts;
+                    }}
+                  >
+                    <ApplicationLoadingOverlayProvider>
+                      <Suspense fallback={<ApplicationLoadingOverlay isOpen />}>
+                        {children}
+                      </Suspense>
+                    </ApplicationLoadingOverlayProvider>
+                  </NavigationPromptCheckpoint>
+                </ActiveBreakpointProvider>
+              </ApplicationIntlProvider>
+            </ApplicationErrorBoundary>
+          </Base>
+        {/* </ThemeContextProvider> */}
+      </ThemeProvider>
+    </div>
   );
 };
 

--- a/src/application-base/ApplicationBase.jsx
+++ b/src/application-base/ApplicationBase.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames/bind';
 import Base from 'terra-base';
 import ThemeProvider from 'terra-theme-provider';
 import { ActiveBreakpointProvider } from 'terra-breakpoints';
-// import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
+import ThemeContextProvider from 'terra-theme-context/lib/ThemeContextProvider';
 
 import ApplicationErrorBoundary from '../application-error-boundary';
 import ApplicationLoadingOverlay, { ApplicationLoadingOverlayProvider } from '../application-loading-overlay';
@@ -69,7 +69,7 @@ const propTypes = {
 };
 
 const ApplicationBase = ({
-  locale, customTranslatedMessages, translationsLoadingPlaceholder, themeName, themeIsGlobal, fitToParentIsDisabled, children, unloadPromptIsDisabled,
+  locale, customTranslatedMessages, translationsLoadingPlaceholder, themeName, fitToParentIsDisabled, children, unloadPromptIsDisabled,
 }) => {
   const registeredPromptsRef = useRef();
 
@@ -106,7 +106,7 @@ const ApplicationBase = ({
       <ThemeProvider
         themeName={themeName}
       >
-        {/* <ThemeContextProvider theme={theme}> */}
+        <ThemeContextProvider theme={theme}>
           <Base
             customMessages={customTranslatedMessages}
             translationsLoadingPlaceholder={translationsLoadingPlaceholder}
@@ -130,7 +130,7 @@ const ApplicationBase = ({
               </ApplicationIntlProvider>
             </ApplicationErrorBoundary>
           </Base>
-        {/* </ThemeContextProvider> */}
+        </ThemeContextProvider>
       </ThemeProvider>
     </div>
   );

--- a/src/application-base/ApplicationBase.module.scss
+++ b/src/application-base/ApplicationBase.module.scss
@@ -1,15 +1,9 @@
 :local {
-  .application-theme-provider {
+  .application-base {
     position: relative;
-  }  
-    
-  .application-theme-provider.fill {
-    height: 100%;
-  } 
+  }
 
   .application-base.fill {
     height: 100%;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
   }
 }

--- a/src/terra-dev-site/doc/application/demo/AppPage.clinical-lowlight-theme.module.scss
+++ b/src/terra-dev-site/doc/application/demo/AppPage.clinical-lowlight-theme.module.scss
@@ -1,0 +1,5 @@
+:local {
+  .clinical-lowlight-theme {
+    --terra-application-app-page-block-background-color: #ffa500;
+  }
+}

--- a/src/terra-dev-site/doc/application/demo/AppPage.jsx
+++ b/src/terra-dev-site/doc/application/demo/AppPage.jsx
@@ -67,6 +67,9 @@ const AppPage = ({ pageName }) => {
       <LoadingOverlayPresenter />
       <ModalPresenter />
       <PendingActionToggle />
+      <h3>Themeing</h3>
+      <p>The div below uses the theme context to apply styling.</p>
+      <div className={cx('themed-block')} />
     </div>
   );
 };

--- a/src/terra-dev-site/doc/application/demo/AppPage.jsx
+++ b/src/terra-dev-site/doc/application/demo/AppPage.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames/bind';
 import { ActiveBreakpointContext } from 'terra-application/lib/breakpoints';
 import ApplicationLoadingOverlay from 'terra-application/lib/application-loading-overlay';
 import { ApplicationIntlContext } from 'terra-application/lib/application-intl';
+import { ThemeContext } from 'terra-application/lib/theme';
 
 import ModalPresenter from './ModalPresenter';
 import PendingActionToggle from './PendingActionToggle';
@@ -20,6 +21,7 @@ const AppPage = ({ pageName }) => {
 
   const activeBreakpoint = useContext(ActiveBreakpointContext);
   const applicationIntl = useContext(ApplicationIntlContext);
+  const theme = React.useContext(ThemeContext);
 
   const [hasError, setHasError] = useState(false);
 
@@ -46,7 +48,7 @@ const AppPage = ({ pageName }) => {
   }
 
   return (
-    <div className={cx('page-content')}>
+    <div className={cx('page-content', theme.className)}>
       <h1>{pageName}</h1>
       <h3>Configuration Properties</h3>
       <p>

--- a/src/terra-dev-site/doc/application/demo/AppPage.module.scss
+++ b/src/terra-dev-site/doc/application/demo/AppPage.module.scss
@@ -1,5 +1,13 @@
+//Themes
+@import './AppPage.clinical-lowlight-theme.module';
+@import './AppPage.orion-fusion-theme.module';
+
 :local {
   .page-content {
     padding: 1.5rem;
+  }
+  .themed-block {
+    background-color: var(--terra-application-app-page-block-background-color, #0079be);
+    height: 1rem;
   }
 }

--- a/src/terra-dev-site/doc/application/demo/AppPage.orion-fusion-theme.module.scss
+++ b/src/terra-dev-site/doc/application/demo/AppPage.orion-fusion-theme.module.scss
@@ -1,0 +1,5 @@
+:local {
+  .orion-fusion-theme {
+    --terra-application-app-page-block-background-color: #9400d3;
+  }
+}

--- a/src/terra-dev-site/doc/application/demo/DemoAppIndex.jsx
+++ b/src/terra-dev-site/doc/application/demo/DemoAppIndex.jsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import ApplicationBase from 'terra-application/lib/application-base';
 import { ApplicationIntlContext } from 'terra-application/lib/application-intl';
 import ModalManager from 'terra-application/lib/modal-manager';
+import { ThemeContext } from 'terra-application/lib/theme';
 
 import DemoAppNavigation from './DemoAppNavigation';
 
@@ -10,9 +11,9 @@ window.TEST_APP_TIMEOUT = 1000;
 
 const DemoAppIndex = () => {
   const applicationIntl = useContext(ApplicationIntlContext);
-
+  const theme = React.useContext(ThemeContext);
   return (
-    <ApplicationBase locale={applicationIntl.locale}>
+    <ApplicationBase locale={applicationIntl.locale} themeName={theme.className}>
       <ModalManager>
         <DemoAppNavigation />
       </ModalManager>

--- a/src/terra-dev-site/doc/application/reference.1/components/ApplicationBase.doc.mdx
+++ b/src/terra-dev-site/doc/application/reference.1/components/ApplicationBase.doc.mdx
@@ -28,7 +28,9 @@ Consumers of ApplicationBase should review Terra's [translation aggregation](htt
 
 ApplicationBase exposes props to define the application's theme.
 
-Consumers of ApplicationBase should review Terra's [theme aggregation](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-themes/README.md) instructions to ensure the all theme properties are loaded appropriately.
+ApplicationBase renders a theme context provider around its children. Children can access the current theme by using the [ThemeContext](/components/terra-application/application/reference/contexts/theme-context).
+
+<!-- Consumers of ApplicationBase should review Terra's [theme aggregation](https://github.com/cerner/terra-toolkit/blob/master/scripts/aggregate-themes/README.md) instructions to ensure the all theme properties are loaded appropriately. -->
 
 ### Breakpoints
 

--- a/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
@@ -2,7 +2,12 @@ import ThemedComponent from './example/ThemedComponent?dev-site-example';
 
 # ThemeContext
 
-The ThemeContext defines an interface for access to the framework's determined active breakpoint based on the current window size.
+The ThemeContext defines an interface for access to the framework's current theme.
+
+This context can be used to apply any theme related changes to a component.
+
+The most common use would be to apply a theme class to the root tag of the component to apply theme variables. See below for an example.
+
 
 > Note: An ThemeContextProvider is rendered by [ApplicationBase](/components/terra-application/application/reference/components/application-base).
 > Any components rendered within ApplicationBase can access a ThemeContext without rendering additional providers.

--- a/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
@@ -8,7 +8,8 @@ The ThemeContext defines an interface for access to the framework's determined a
 > Any components rendered within ApplicationBase can access a ThemeContext without rendering additional providers.
 
 ## Usage
-<ThemedComponent />
+
+<ThemedComponent description="This example pulls the current theme from the theme context and adds the theme class name to apply theme variables." isExpanded />
 
 ## Context Value
 
@@ -16,4 +17,4 @@ The ThemeContext provides an object with the following values:
 
 |Key Name|Type|Is Required|DefaultValue|Description|
 |---|---|---|---|---|
-|`className`|String|optional|undefined|The current application theme className. The default theme is indicated as undefined|
+|`className`|String|optional|undefined|The current application theme className. The default theme is indicated as undefined or empty string.|

--- a/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
@@ -1,3 +1,5 @@
+import ThemedComponent from './example/ThemedComponent?dev-site-example';
+
 # ThemeContext
 
 The ThemeContext defines an interface for access to the framework's determined active breakpoint based on the current window size.
@@ -6,6 +8,7 @@ The ThemeContext defines an interface for access to the framework's determined a
 > Any components rendered within ApplicationBase can access a ThemeContext without rendering additional providers.
 
 ## Usage
+<ThemedComponent />
 
 ## Context Value
 

--- a/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/ThemeContext.doc.mdx
@@ -1,0 +1,16 @@
+# ThemeContext
+
+The ThemeContext defines an interface for access to the framework's determined active breakpoint based on the current window size.
+
+> Note: An ThemeContextProvider is rendered by [ApplicationBase](/components/terra-application/application/reference/components/application-base).
+> Any components rendered within ApplicationBase can access a ThemeContext without rendering additional providers.
+
+## Usage
+
+## Context Value
+
+The ThemeContext provides an object with the following values:
+
+|Key Name|Type|Is Required|DefaultValue|Description|
+|---|---|---|---|---|
+|`className`|String|optional|undefined|The current application theme className. The default theme is indicated as undefined|

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.clinical-lowlight-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.clinical-lowlight-theme.module.scss
@@ -1,0 +1,5 @@
+:local {
+  .clinical-lowlight-theme {
+    --terra-theme-context-themed-component-block-background-color: #ffa500;
+  }
+}

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.clinical-lowlight-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.clinical-lowlight-theme.module.scss
@@ -1,5 +1,5 @@
 :local {
   .clinical-lowlight-theme {
-    --terra-theme-context-themed-component-block-background-color: #ffa500;
+    --terra-application-themed-component-block-background-color: #ffa500;
   }
 }

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.jsx
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import classNames from 'classnames/bind';
+import { ThemeContext } from 'terra-application/lib/theme';
+
+import styles from './ThemedComponent.module.scss';
+
+const cx = classNames.bind(styles);
+
+const Themed = () => {
+  const theme = React.useContext(ThemeContext);
+  return (
+    <div className={cx('themed', theme.className)}>
+      <h1>
+        Themed block
+      </h1>
+      <div className={cx('themed-block')} />
+    </div>
+  );
+};
+
+export default Themed;

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.module.scss
@@ -1,0 +1,18 @@
+//Themes
+@import './ThemedComponent.clinical-lowlight-theme.module';
+@import './ThemedComponent.orion-fusion-theme.module';
+@import './ThemedComponent.test-theme.module';
+
+:local {
+  .themed {
+    height: 100%;
+    overflow: auto;
+    padding: 24px;
+    position: relative;
+  }
+
+  .themed-block {
+    background-color: var(--terra-theme-context-themed-component-block-background-color, #0079be);
+    height: 24px;
+  }
+}

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.module.scss
@@ -1,7 +1,6 @@
 //Themes
 @import './ThemedComponent.clinical-lowlight-theme.module';
 @import './ThemedComponent.orion-fusion-theme.module';
-@import './ThemedComponent.test-theme.module';
 
 :local {
   .themed {
@@ -12,7 +11,7 @@
   }
 
   .themed-block {
-    background-color: var(--terra-theme-context-themed-component-block-background-color, #0079be);
+    background-color: var(--terra-application-themed-component-block-background-color, #0079be);
     height: 24px;
   }
 }

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.orion-fusion-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.orion-fusion-theme.module.scss
@@ -1,0 +1,5 @@
+:local {
+  .orion-fusion-theme {
+    --terra-theme-context-themed-component-block-background-color: #9400d3;
+  }
+}

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.orion-fusion-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.orion-fusion-theme.module.scss
@@ -1,5 +1,5 @@
 :local {
   .orion-fusion-theme {
-    --terra-theme-context-themed-component-block-background-color: #9400d3;
+    --terra-application-themed-component-block-background-color: #9400d3;
   }
 }

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.test-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.test-theme.module.scss
@@ -1,5 +1,0 @@
-:local {
-  .test-theme {
-    --terra-theme-context-themed-component-block-background-color: #009d00;
-  }
-}

--- a/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.test-theme.module.scss
+++ b/src/terra-dev-site/doc/application/reference.1/contexts/example/ThemedComponent.test-theme.module.scss
@@ -1,0 +1,5 @@
+:local {
+  .test-theme {
+    --terra-theme-context-themed-component-block-background-color: #009d00;
+  }
+}

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/prefer-default-export
-export { ThemeContext } from 'terra-theme-context';
+export { default as ThemeContext, themeContextShape } from 'terra-theme-context';

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { ThemeContext } from 'terra-theme-context';

--- a/terra-theme.config.js
+++ b/terra-theme.config.js
@@ -1,0 +1,8 @@
+const themeConfig = {
+  scoped: [
+    'clinical-lowlight-theme',
+    'orion-fusion-theme',
+  ],
+};
+
+module.exports = themeConfig;

--- a/tests/jest/application-base/__snapshots__/ApplicationBase.test.jsx.snap
+++ b/tests/jest/application-base/__snapshots__/ApplicationBase.test.jsx.snap
@@ -1,125 +1,153 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationBase should render with all props 1`] = `
-<ThemeProvider
-  className="application-theme-provider"
-  isGlobalTheme={true}
-  themeName="test-theme"
+<div
+  className="application-base"
 >
-  <Base
-    customMessages={
-      Object {
-        "custom": "messages",
-      }
-    }
-    locale="en"
-    strictMode={false}
-    translationsLoadingPlaceholder={
-      <div>
-        placeholder
-      </div>
-    }
+  <ThemeProvider
+    themeName="test-theme"
   >
-    <ApplicationErrorBoundary>
-      <InjectIntl(Component)>
-        <ActiveBreakpointProvider>
-          <withPromptRegistration(NavigationPromptCheckpoint)
-            onPromptChange={[Function]}
-          >
-            <ApplicationLoadingOverlayProvider>
-              <Suspense
-                fallback={
-                  <ApplicationLoadingOverlay
-                    backgroundStyle="clear"
-                    isOpen={true}
-                  />
-                }
+    <ThemeContextProvider
+      theme={
+        Object {
+          "className": "test-theme",
+        }
+      }
+    >
+      <Base
+        customMessages={
+          Object {
+            "custom": "messages",
+          }
+        }
+        locale="en"
+        strictMode={false}
+        translationsLoadingPlaceholder={
+          <div>
+            placeholder
+          </div>
+        }
+      >
+        <ApplicationErrorBoundary>
+          <InjectIntl(Component)>
+            <ActiveBreakpointProvider>
+              <withPromptRegistration(NavigationPromptCheckpoint)
+                onPromptChange={[Function]}
               >
-                <div>
-                  content
-                </div>
-              </Suspense>
-            </ApplicationLoadingOverlayProvider>
-          </withPromptRegistration(NavigationPromptCheckpoint)>
-        </ActiveBreakpointProvider>
-      </InjectIntl(Component)>
-    </ApplicationErrorBoundary>
-  </Base>
-</ThemeProvider>
+                <ApplicationLoadingOverlayProvider>
+                  <Suspense
+                    fallback={
+                      <ApplicationLoadingOverlay
+                        backgroundStyle="clear"
+                        isOpen={true}
+                      />
+                    }
+                  >
+                    <div>
+                      content
+                    </div>
+                  </Suspense>
+                </ApplicationLoadingOverlayProvider>
+              </withPromptRegistration(NavigationPromptCheckpoint)>
+            </ActiveBreakpointProvider>
+          </InjectIntl(Component)>
+        </ApplicationErrorBoundary>
+      </Base>
+    </ThemeContextProvider>
+  </ThemeProvider>
+</div>
 `;
 
 exports[`ApplicationBase should render with minimal props 1`] = `
-<ThemeProvider
-  className="application-theme-provider fill"
-  isGlobalTheme={false}
+<div
+  className="application-base fill"
 >
-  <Base
-    customMessages={Object {}}
-    locale="en"
-    strictMode={false}
-  >
-    <ApplicationErrorBoundary>
-      <InjectIntl(Component)>
-        <ActiveBreakpointProvider>
-          <withPromptRegistration(NavigationPromptCheckpoint)
-            onPromptChange={[Function]}
-          >
-            <ApplicationLoadingOverlayProvider>
-              <Suspense
-                fallback={
-                  <ApplicationLoadingOverlay
-                    backgroundStyle="clear"
-                    isOpen={true}
-                  />
-                }
+  <ThemeProvider>
+    <ThemeContextProvider
+      theme={
+        Object {
+          "className": undefined,
+        }
+      }
+    >
+      <Base
+        customMessages={Object {}}
+        locale="en"
+        strictMode={false}
+      >
+        <ApplicationErrorBoundary>
+          <InjectIntl(Component)>
+            <ActiveBreakpointProvider>
+              <withPromptRegistration(NavigationPromptCheckpoint)
+                onPromptChange={[Function]}
               >
-                <div>
-                  content
-                </div>
-              </Suspense>
-            </ApplicationLoadingOverlayProvider>
-          </withPromptRegistration(NavigationPromptCheckpoint)>
-        </ActiveBreakpointProvider>
-      </InjectIntl(Component)>
-    </ApplicationErrorBoundary>
-  </Base>
-</ThemeProvider>
+                <ApplicationLoadingOverlayProvider>
+                  <Suspense
+                    fallback={
+                      <ApplicationLoadingOverlay
+                        backgroundStyle="clear"
+                        isOpen={true}
+                      />
+                    }
+                  >
+                    <div>
+                      content
+                    </div>
+                  </Suspense>
+                </ApplicationLoadingOverlayProvider>
+              </withPromptRegistration(NavigationPromptCheckpoint)>
+            </ActiveBreakpointProvider>
+          </InjectIntl(Component)>
+        </ApplicationErrorBoundary>
+      </Base>
+    </ThemeContextProvider>
+  </ThemeProvider>
+</div>
 `;
 
 exports[`ApplicationBase should render with the preferred browser local 1`] = `
-<ThemeProvider
-  className="application-theme-provider fill"
-  isGlobalTheme={false}
+<div
+  className="application-base fill"
 >
-  <Base
-    customMessages={Object {}}
-    locale="en"
-    strictMode={false}
-  >
-    <ApplicationErrorBoundary>
-      <InjectIntl(Component)>
-        <ActiveBreakpointProvider>
-          <withPromptRegistration(NavigationPromptCheckpoint)
-            onPromptChange={[Function]}
-          >
-            <ApplicationLoadingOverlayProvider>
-              <Suspense
-                fallback={
-                  <ApplicationLoadingOverlay
-                    backgroundStyle="clear"
-                    isOpen={true}
-                  />
-                }
+  <ThemeProvider>
+    <ThemeContextProvider
+      theme={
+        Object {
+          "className": undefined,
+        }
+      }
+    >
+      <Base
+        customMessages={Object {}}
+        locale="en"
+        strictMode={false}
+      >
+        <ApplicationErrorBoundary>
+          <InjectIntl(Component)>
+            <ActiveBreakpointProvider>
+              <withPromptRegistration(NavigationPromptCheckpoint)
+                onPromptChange={[Function]}
               >
-                <div>
-                  content
-                </div>
-              </Suspense>
-            </ApplicationLoadingOverlayProvider>
-          </withPromptRegistration(NavigationPromptCheckpoint)>
-        </ActiveBreakpointProvider>
-      </InjectIntl(Component)>
-    </ApplicationErrorBoundary>
-  </Base>
-</ThemeProvider>
+                <ApplicationLoadingOverlayProvider>
+                  <Suspense
+                    fallback={
+                      <ApplicationLoadingOverlay
+                        backgroundStyle="clear"
+                        isOpen={true}
+                      />
+                    }
+                  >
+                    <div>
+                      content
+                    </div>
+                  </Suspense>
+                </ApplicationLoadingOverlayProvider>
+              </withPromptRegistration(NavigationPromptCheckpoint)>
+            </ActiveBreakpointProvider>
+          </InjectIntl(Component)>
+        </ApplicationErrorBoundary>
+      </Base>
+    </ThemeContextProvider>
+  </ThemeProvider>
+</div>
 `;

--- a/tests/jest/theme/index.test.js
+++ b/tests/jest/theme/index.test.js
@@ -1,0 +1,14 @@
+import {
+  ThemeContext,
+  themeContextShape,
+} from '../../../src/theme';
+
+describe('theme/index', () => {
+  it('should export ThemeContext', () => {
+    expect(ThemeContext).toBeDefined();
+  });
+
+  it('should export themeContextShape', () => {
+    expect(themeContextShape).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Summary
The ThemeContext defines an interface for access to the framework's current theme.

This context can be used to apply any theme related changes to a component.

The most common use would be to apply a theme class to the root tag of the component to apply theme variables. See below for an example.

As a part of updating theme provider the `themeIsGlobal` prop has been removed. While this traditionally would be considered non-passive, this prop was broken and I would consider it's presence a bug.

### Deployment Link
https://terra-applic-theme-cont-kndjvz.herokuapp.com/home

### Testing
This has been tested using jest as well as having been tested in the terra-framework package.

### Additional Details
I've also added theme switching to this repo.

Thank you for contributing to Terra.
@cerner/terra
