### PR TITLE
Apply theme name to theme context

### DIFF
--- a/src/application-base/ApplicationBase.jsx
+++ b/src/application-base/ApplicationBase.jsx
@@ -17,9 +17,15 @@ import useTestOverrides from './private/useTestOverrides';
 
 import styles from './ApplicationBase.module.scss';
 
+/* global TERRA_THEME_CONFIG */
+
 const cx = classNames.bind(styles);
 
 const browserLocale = getBrowserLocale();
+
+// We only need to retrieve the root theme and root theme name once for the life of the application.
+const themeConfig = (typeof (TERRA_THEME_CONFIG) !== 'undefined') ? TERRA_THEME_CONFIG : undefined;
+const rootThemeName = themeConfig?.theme ? themeConfig.theme : 'terra-default-theme';
 
 const propTypes = {
   /**
@@ -101,7 +107,12 @@ const ApplicationBase = ({
   }, [unloadPromptIsDisabled, registeredPromptsRef]);
 
   const { localeOverride } = useTestOverrides(); // Allows us to test deployed applications in different locales.
-  const theme = useMemo(() => ({ className: themeName }), [themeName]);
+
+  const theme = useMemo(() => ({
+    // If the theme class name is undefined or an empty string, that indicates we have the root theme and should apply the root theme name.
+    name: themeName || rootThemeName,
+    className: themeName,
+  }), [themeName]);
 
   return (
     <div className={cx('application-base', { fill: !fitToParentIsDisabled })}>

--- a/src/terra-dev-site/app/contexts.2/ThemeContext.app.mdx
+++ b/src/terra-dev-site/app/contexts.2/ThemeContext.app.mdx
@@ -22,4 +22,5 @@ The ThemeContext provides an object with the following values:
 
 |Key Name|Type|Is Required|DefaultValue|Description|
 |---|---|---|---|---|
+|`name`|String|optional|undefined|The current application theme name. This field requires use of the terra-toolkit webpack config.|
 |`className`|String|optional|undefined|The current application theme className. The default theme is indicated as undefined or empty string.|

--- a/src/terra-dev-site/app/contexts.2/example/ThemedComponent.jsx
+++ b/src/terra-dev-site/app/contexts.2/example/ThemedComponent.jsx
@@ -11,7 +11,7 @@ const Themed = () => {
   return (
     <div className={cx('themed', theme.className)}>
       <h1>
-        Themed block
+        {`Theme Name: ${theme.name}`}
       </h1>
       <div className={cx('themed-block')} />
     </div>

--- a/src/terra-dev-site/app/demo/AppPage.jsx
+++ b/src/terra-dev-site/app/demo/AppPage.jsx
@@ -68,7 +68,7 @@ const AppPage = ({ pageName }) => {
       <ModalPresenter />
       <PendingActionToggle />
       <h3>Themeing</h3>
-      <p>The div below uses the theme context to apply styling.</p>
+      <p>{`The div below uses the theme context to apply styling for theme: ${theme.name}.`}</p>
       <div className={cx('themed-block')} />
     </div>
   );

--- a/src/theme/ThemeContextProvider.js
+++ b/src/theme/ThemeContextProvider.js
@@ -1,0 +1,1 @@
+export { default } from 'terra-theme-context/lib/ThemeContextProvider';

--- a/tests/jest/application-base/__snapshots__/ApplicationBase.test.jsx.snap
+++ b/tests/jest/application-base/__snapshots__/ApplicationBase.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`ApplicationBase should render with all props 1`] = `
       theme={
         Object {
           "className": "test-theme",
+          "name": "test-theme",
         }
       }
     >
@@ -67,6 +68,7 @@ exports[`ApplicationBase should render with minimal props 1`] = `
       theme={
         Object {
           "className": undefined,
+          "name": "terra-default-theme",
         }
       }
     >
@@ -114,6 +116,7 @@ exports[`ApplicationBase should render with the preferred browser local 1`] = `
       theme={
         Object {
           "className": undefined,
+          "name": "terra-default-theme",
         }
       }
     >

--- a/tests/jest/theme/ThemeContextProvider.js
+++ b/tests/jest/theme/ThemeContextProvider.js
@@ -1,0 +1,7 @@
+import ThemeProviderContext from '../../../src/theme/ThemeContextProvider';
+
+describe('theme/index', () => {
+  it('should export ThemeProviderContext as default', () => {
+    expect(ThemeProviderContext).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Summary
This will use the theme config to apply the appropriate theme name to the theme context 

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-35.herokuapp.com/

### Testing
Jest

### Additional Details
I've also exported the theme provider here because I think it's required for testing theme changes in custom components.

Related PRs:
https://github.com/cerner/terra-toolkit-boneyard/pull/33
https://github.com/cerner/terra-framework/pull/1101
<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
