### PR TITLE
Move release message under correct release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Unreleased
 ### Added
 * Added a logger utility.
 
+### Changes
+* Updated errorBoundary to have a default error message when there is none provided.
+
 1.25.0 - (June 9, 2020)
 ------------------
 ### Changed
@@ -38,7 +41,6 @@ Unreleased
 1.22.0 - (April 28, 2020)
 ------------------
 ### Changed
-* Updated errorBoundary to have a default error message when there is none provided.
 * Update terra-toolkit dev dependency to 6.0.0
 
 1.21.0 - (April 22, 2020)


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This was accidently added to the wrong release section when merged 10 days ago: https://github.com/cerner/terra-application/pull/32/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR29

This should be under 1.26.0 - (June 16, 2020)


### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
- project tests

Thank you for contributing to Terra.
@cerner/terra
