### PR TITLE
Returning Promise from registerDismissCheck to remain passive with default implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+### Fixed
+* Returning Promise from registerDismissCheck implementation
+
 1.29.0 - (July 15, 2020)
 ------------------
 ### Fixed

--- a/src/disclosure-manager/_DisclosureContainer.jsx
+++ b/src/disclosure-manager/_DisclosureContainer.jsx
@@ -36,7 +36,14 @@ const DisclosureContainer = injectIntl(({ intl, children, navigationPromptResolu
   const customRegisterDismissCheckRef = useRef();
 
   const overrideDisclosureManagerContext = useMemo(() => DisclosureManagerDelegate.clone(disclosureManager, {
-    registerDismissCheck: (check) => { customRegisterDismissCheckRef.current = check; },
+    registerDismissCheck: (check) => {
+      customRegisterDismissCheckRef.current = check;
+
+      /**
+       * Return Promise to align with DisclosureManager's default implementation.
+       */
+      return Promise.resolve();
+    },
   }), [disclosureManager]);
 
   const defaultPromptOptions = useMemo(() => getUnsavedChangesPromptOptions(intl), [intl]);

--- a/src/terra-dev-site/test/modal-manager/DisclosureComponent.jsx
+++ b/src/terra-dev-site/test/modal-manager/DisclosureComponent.jsx
@@ -55,7 +55,7 @@ class DisclosureComponent extends React.Component {
     });
 
     if (this.props.useCustomDismissCheck && this.props.disclosureManager.registerDismissCheck) {
-      this.props.disclosureManager.registerDismissCheck(() => Promise.reject());
+      this.props.disclosureManager.registerDismissCheck(() => Promise.reject()).then(() => { /* registerDismissCheck should return a Promise, so this should not throw an exception */ });
     }
   }
 


### PR DESCRIPTION
### Summary
I forgot to return a Promise from the registerDismissCheck override. The default implementation does, and some consumers were using it. I'm now returning a Promise from the overridden function.

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-register-d-f1vubq.herokuapp.com/

### Testing
Existing wdio tests have been updated to utilize the returned Promise. Screenshots would show errors if the Promise was not being returned.

### Additional Details
Argh

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
