### PR TITLE
Fix ApplicationStatusOverlayProvider contextType warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Fix ApplicationStatusOverlayProvider contextType warning
+
 ## 1.30.0 - (Aug 11, 2020)
 
 * Added

--- a/src/application-status-overlay/ApplicationStatusOverlayProvider.jsx
+++ b/src/application-status-overlay/ApplicationStatusOverlayProvider.jsx
@@ -116,6 +116,5 @@ const ApplicationStatusOverlayProvider = ({ children, scrollRefCallback, ...cust
 };
 
 ApplicationStatusOverlayProvider.propTypes = propTypes;
-ApplicationStatusOverlayProvider.contextType = ThemeContext;
 
 export default ApplicationStatusOverlayProvider;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->

This PR resolves the contextType warning that is logged to the console. The warning is generated because functional components do not support static contextType declarations.

The functional component is already using `useContext` appropriately. The contextType declaration is unneeded.

Closes #69 

Thank you for contributing to Terra.
@cerner/terra
