### PR TITLE
Reverting uuid update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Changed
-  * Reverted "Updated `uuid` dependency to `v8.0.0`" due to IE10 compatability issues
+  * Reverted "Updated `uuid` dependency to `v8.0.0`" due to IE10 compatibility issues
 
 ## 1.31.0 - (Aug 18, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Reverted "Updated `uuid` dependency to `v8.0.0`" due to IE10 compatability issues
+
 ## 1.31.0 - (Aug 18, 2020)
 
 * Changed

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "terra-status-view": "^4.10.0",
     "terra-theme-context": "^1.0.0",
     "terra-theme-provider": "^4.0.0",
-    "uuid": "^8.0.0",
+    "uuid": "^3.0.0",
     "wicg-inert": "^3.0.2"
   },
   "peerDependencies": {

--- a/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
+++ b/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
@@ -1,6 +1,6 @@
 import { useRef, useContext, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
-import { v4 as uuidv4 } from 'uuid';
+import uuidv4 from 'uuid/v4';
 
 import ApplicationLoadingOverlayContext from './ApplicationLoadingOverlayContext';
 

--- a/src/application-status-overlay/ApplicationStatusOverlay.jsx
+++ b/src/application-status-overlay/ApplicationStatusOverlay.jsx
@@ -1,7 +1,7 @@
 import { useRef, useContext, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import Button from 'terra-button';
-import { v4 as uuidv4 } from 'uuid';
+import uuidv4 from 'uuid/v4';
 import ApplicationStatusOverlayContext from './ApplicationStatusOverlayContext';
 
 const propTypes = {

--- a/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
+++ b/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import uuidv4 from 'uuid/v4';
 
 import ApplicationLoadingOverlay from '../../../src/application-loading-overlay/ApplicationLoadingOverlay';
 import ApplicationLoadingOverlayContext from '../../../src/application-loading-overlay/ApplicationLoadingOverlayContext';
 
-jest.mock('uuid');
+jest.mock('uuid/v4');
 
 describe('ApplicationLoadingOverlay', () => {
   let reactUseContext;

--- a/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
+++ b/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { v4 as uuidv4 } from 'uuid';
+import uuidv4 from 'uuid/v4';
 
 import ApplicationStatusOverlay from '../../../src/application-status-overlay/ApplicationStatusOverlay';
 import ApplicationStatusOverlayContext from '../../../src/application-status-overlay/ApplicationStatusOverlayContext';
 
-jest.mock('uuid');
+jest.mock('uuid/v4');
 
 describe('ApplicationStatusOverlay', () => {
   let reactUseContext;


### PR DESCRIPTION
### Summary

IE10 compatibility was dropped with versions 7/8 of uuid. We need to go back to v3.