### PR TITLE
Lock down navigation-prompt-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Changed
   * Updated `uuid` dependency to `v8.0.0`.
+  * Lock down terra-navigation-prompt to ensure MVB of terra-notification-dialog is consumed correctly
+
 * Fixed
   * Fix ApplicationStatusOverlayProvider contextType warning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Lock down terra-navigation-prompt to ensure MVB of terra-notification-dialog is consumed correctly
+
 ## 1.31.1 - (Aug 19, 2020)
 
 * Changed
@@ -11,7 +14,6 @@
 
 * Changed
   * Updated `uuid` dependency to `v8.0.0`.
-  * Lock down terra-navigation-prompt to ensure MVB of terra-notification-dialog is consumed correctly
 
 * Fixed
   * Fix ApplicationStatusOverlayProvider contextType warning

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "terra-disclosure-manager": "^4.27.0",
     "terra-doc-template": "^2.2.0",
     "terra-modal-manager": "^6.20.0",
-    "terra-navigation-prompt": "^1.18.0",
+    "terra-navigation-prompt": "1.39.0",
     "terra-overlay": "^3.32.0",
     "terra-scroll": "^2.18.0",
     "terra-slide-panel-manager": "^5.19.0",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
Terra-application will need updated to handle the list formatting expected  with the latest designs of terra-notification-dialog/terra-navigation-prompt when there are multiple pending-actions in a notification dialog.

Currently there is caused a visual difference due to the native list styles.

See: https://github.com/cerner/terra-framework/pull/1105#issuecomment-676606484


### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-lock-dialo-iurv0n.herokuapp.com/home

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Project tests.

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

Updating changes to unlock this: https://github.com/cerner/terra-application/compare/unsaved-changes

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
