### PR TITLE
Updating documentation for ApplicationBase and its unsaved changes handling across browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated documentation for ApplicationBase and its unsaved changes handling across browsers.
+
 ## 1.34.0 - (September 8, 2020)
 
 * Added

--- a/src/terra-dev-site/app/components.2/ApplicationBase.app.mdx
+++ b/src/terra-dev-site/app/components.2/ApplicationBase.app.mdx
@@ -50,7 +50,10 @@ ApplicationBase renders an [ApplicationStatusOverlayProvider](/application/terra
 
 ### Unsaved Changes
 
-ApplicationBase monitors its children for the presence of rendered [NavigationPrompts](/application/terra-application/components/navigation-prompt). ApplicationBase will ensure that the user is prompted using a browser-native confirmation dialog prior to any window unload event if any [NavigationPrompts](/application/terra-application/components/navigation-prompt) are rendered at the time of the unload request.
+ApplicationBase monitors its children for the presence of rendered [NavigationPrompts](/application/terra-application/components/navigation-prompt). ApplicationBase will prompt the user, if possible, using a browser-native confirmation dialog prior to any window unload event if any [NavigationPrompts](/application/terra-application/components/navigation-prompt) are rendered at the time of the unload request.
+
+> Note that support for the `beforeunload` event used to implement this functionality varies across terra-application's supported browsers. Some browsers, namely those running on iOS and Android, do not support the `beforeunload` event and do not allow the framework to prevent the application's dismissal, even if unsaved changes are present. Other browsers allow their users to explicitly disable this event to avoid malicious or otherwise obtrusive implementations.
+Please review the [event's documentation](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Browser_compatibility) for more information.
 
 ### Code Splitting
 


### PR DESCRIPTION
### Summary

The `beforeunload` event used by ApplicationBase to detect unsaved changes and prompt the user before unloading the window has varying levels of support. In mobile browsers, the event is ignored, and there's no alternative implementation. 

I've updated the docs to bring attention to this difference in behavior.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #78.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
