### PR TITLE
Remove terra-doc-template dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Removed terra-doc-template dependency.
+
 ## 1.36.0 - (September 29, 2020)
 
 * Changed

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "terra-button": "^3.42.0",
     "terra-content-container": "^3.14.0",
     "terra-disclosure-manager": "^4.27.0",
-    "terra-doc-template": "^2.2.0",
     "terra-modal-manager": "^6.20.0",
     "terra-navigation-prompt": "^1.40.0",
     "terra-notification-dialog": "^4.0.0",


### PR DESCRIPTION
### Summary
We don't use doc template and it relies on an old version of core-js. this eliminates the duplicate.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
