### PR TITLE
Move development dependencies into devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Moved development dependencies into devDependencies
+
 ## 1.41.1 - (January 8, 2021)
 
 * Changed

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "wdio": "npm run wdio-default && npm run wdio-locale && npm run wdio-lowlight && npm run wdio-fusion"
   },
   "dependencies": {
+    "@cerner/terra-docs": "^1.0.0",
     "classnames": "^2.2.5",
     "eventemitter3": "^4.0.4",
     "mutationobserver-shim": "0.3.3",
@@ -129,7 +130,6 @@
     "@babel/core": "7.10.5",
     "@babel/parser": "7.10.5",
     "@cerner/terra-cli": "^1.0.0",
-    "@cerner/terra-docs": "^1.0.0",
     "@cerner/terra-open-source-scripts": "^1.0.1",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -96,9 +96,6 @@
     "wdio": "npm run wdio-default && npm run wdio-locale && npm run wdio-lowlight && npm run wdio-fusion"
   },
   "dependencies": {
-    "@cerner/terra-cli": "^1.0.0",
-    "@cerner/terra-docs": "^1.0.0",
-    "@cerner/terra-open-source-scripts": "^1.0.1",
     "classnames": "^2.2.5",
     "eventemitter3": "^4.0.4",
     "mutationobserver-shim": "0.3.3",
@@ -131,6 +128,9 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "7.10.5",
     "@babel/parser": "7.10.5",
+    "@cerner/terra-cli": "^1.0.0",
+    "@cerner/terra-docs": "^1.0.0",
+    "@cerner/terra-open-source-scripts": "^1.0.1",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@babel/plugin-transform-async-to-generator": "^7.8.3",


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

This PR moves a couple cli development dependencies that were listed in `dependencies` into `devDependencies` to prevent them from being bundled into downstream installations. 

Thank you for contributing to Terra.
@cerner/terra
