### PR TITLE
Injecting intl into NotificationBanner components for usage outside of ApplicationBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Injecting intl into NotificationBanner components for usage outside of ApplicationBase
+
 ## 1.43.0 - (February 23, 2021)
 
 * Added

--- a/src/notification-banner/private/_NotificationBannerView.jsx
+++ b/src/notification-banner/private/_NotificationBannerView.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import classNamesBind from 'classnames/bind';
+import { injectIntl } from 'react-intl';
 import Button from 'terra-button';
 import IconAlert from 'terra-icon/lib/icon/IconAlert';
 import IconError from 'terra-icon/lib/icon/IconError';
@@ -8,11 +11,7 @@ import IconGapChecking from 'terra-icon/lib/icon/IconGapChecking';
 import IconDiamondSymbol from 'terra-icon/lib/icon/IconDiamondSymbol';
 import IconInformation from 'terra-icon/lib/icon/IconInformation';
 import IconSuccess from 'terra-icon/lib/icon/IconSuccess';
-import classNames from 'classnames';
-import classNamesBind from 'classnames/bind';
 import ThemeContext from 'terra-theme-context';
-
-import { ApplicationIntlContext } from '../../application-intl';
 
 import useElementSize, { breakpointFilter } from './useElementSize';
 
@@ -76,6 +75,10 @@ const propTypes = {
     NotificationTypes.SUCCESS,
     NotificationTypes.CUSTOM,
   ]),
+  /**
+   * @private
+   */
+  intl: PropTypes.shape({ formatMessage: PropTypes.func }),
 };
 
 const defaultProps = {
@@ -117,10 +120,10 @@ const NotificationBannerView = ({
   onDismiss,
   title,
   type,
+  intl,
   ...customProps
 }) => {
   const theme = React.useContext(ThemeContext);
-  const intl = React.useContext(ApplicationIntlContext);
   const containerRef = React.useRef();
   const { activeBreakpoint } = useElementSize(containerRef, breakpointFilter);
 
@@ -183,5 +186,5 @@ const NotificationBannerView = ({
 NotificationBannerView.propTypes = propTypes;
 NotificationBannerView.defaultProps = defaultProps;
 
-export default NotificationBannerView;
+export default injectIntl(NotificationBannerView);
 export { getTitleStringIdForType, NotificationTypes };

--- a/src/notification-banner/private/useNotificationBanners.jsx
+++ b/src/notification-banner/private/useNotificationBanners.jsx
@@ -2,11 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNamesBind from 'classnames/bind';
 import classNames from 'classnames';
-
+import { injectIntl } from 'react-intl';
 import Button from 'terra-button';
 import ThemeContext from 'terra-theme-context';
-
-import { ApplicationIntlContext } from '../../application-intl';
 
 import BannerRegistrationContext from './BannerRegistrationContext';
 import organizeBannersByPriority from './organizeBannersByPriority';
@@ -158,10 +156,9 @@ const useNotificationBanners = () => {
      * Renders a list of prioritized notification banners.
      */
     const NotificationBanners = ({
-      id, label, activeClassName, bannerClassName,
+      id, label, activeClassName, bannerClassName, intl,
     }) => {
       const theme = React.useContext(ThemeContext);
-      const intl = React.useContext(ApplicationIntlContext);
       const [bannerState, setBannerState] = React.useState({});
 
       // The container reference points to the notification region so we
@@ -386,11 +383,15 @@ const useNotificationBanners = () => {
        * A className applied to each rendered notification banner.
        */
       bannerClassName: PropTypes.string,
+      /**
+       * @private
+       */
+      intl: PropTypes.shape({ formatMessage: PropTypes.func }),
     };
 
     return {
       NotificationBannerProvider,
-      NotificationBanners,
+      NotificationBanners: injectIntl(NotificationBanners),
     };
   }, []);
 

--- a/tests/jest/disclosure-manager/__snapshots__/DisclosureContainer.test.jsx.snap
+++ b/tests/jest/disclosure-manager/__snapshots__/DisclosureContainer.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`DisclosureContainer should render the provided children 1`] = `
       <withPromptRegistration(NavigationPromptCheckpoint)>
         <ContentContainer
           fill={true}
-          header={<NotificationBanners />}
+          header={<InjectIntl(NotificationBanners) />}
         >
           <NotificationBannerProvider>
             <div>


### PR DESCRIPTION
### Summary

These components are used in some scenarios where ApplicationBase is not used and the ApplicationIntlContext is not provided. This change will allow these scenarios to continue working.