### PR TITLE
Rollback supported node versions to remain passive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ stats.json
 aggregated-themes.js
 package-lock.json
 generated-themes
+docker_images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   * Removed terra-toolkit as a dependency
   * Upgraded to WebDriverIO v6 and terra-functional-testing
   * Upgraded to @cerner/webpack-config-terra
+  * Upgraded to support Node 12
+
+* Fixed
+  * Ignore docker_images folder when publishing
 
 ## 1.47.1 - (April 27, 2021)
 
@@ -15,7 +19,7 @@
 ## 1.47.0 - (April 13, 2021)
 
 * Added
-  * Added fallback locale logic that takes locale from preferred unsupported regional locale. 
+  * Added fallback locale logic that takes locale from preferred unsupported regional locale.
 
 ## 1.46.0 - (March 30, 2021)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.47.1",
   "description": "A framework to support application development with Terra components",
   "engines": {
-    "node": ">=10 <15"
+    "node": ">=8.9.2 <15"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Summary

- > It's non passive to drop support for older versions of node. We don't support older versions when testing but consumers can still use them on older versions.

- ignore docker images to avoid publishing large package size.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
