### PR TITLE
Adding MutationObserver to terra-polyfill

### DIFF
--- a/packages/terra-application-docs/CHANGELOG.md
+++ b/packages/terra-application-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated docs for terra-polyfill
+
 ## 1.1.0 - (August 11, 2021)
 
 * Changed

--- a/packages/terra-application-docs/src/terra-dev-site/app/Polyfills.1.app.mdx
+++ b/packages/terra-application-docs/src/terra-dev-site/app/Polyfills.1.app.mdx
@@ -25,6 +25,7 @@ import '@cerner/terra-polyfill';
 * [`regenerator-runtime`](https://www.npmjs.com/package/regenerator-runtime) - Standalone runtime for Regenerator-compiled generator and async functions
 * ['whatwg-fetch'](https://www.npmjs.com/package/whatwg-fetch) - A window.fetch polyfill
 * ['abortcontroller-polyfill'](https://www.npmjs.com/package/abortcontroller-polyfill) - An AbortController polyfill
+* ['mutationobserver-shim'](https://www.npmjs.com/package/mutationobserver-shim/v/0.3.3) - A polyfill for the MutationObserver API
 * [HTMLElement.inert](https://www.npmjs.com/package/wicg-inert)
 * [Node.contains](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)
 * [Element.matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches)

--- a/packages/terra-polyfill/CHANGELOG.md
+++ b/packages/terra-polyfill/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Adding MutationObserver polyfill to meet inert polyfill requirements
+
 ## 1.0.0 - (August 11, 2021)
 
 * Initial stable release

--- a/packages/terra-polyfill/package.json
+++ b/packages/terra-polyfill/package.json
@@ -39,6 +39,7 @@
     "abortcontroller-polyfill": "^1.7.3",
     "core-js": "^3.15.2",
     "intl": "^1.2.5",
+    "mutationobserver-shim": "0.3.3",
     "regenerator-runtime": "^0.13.9",
     "whatwg-fetch": "^3.6.2",
     "wicg-inert": "^3.0.2"

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -21,6 +21,12 @@ import 'whatwg-fetch';
 import 'abortcontroller-polyfill';
 
 /**
+ * Polyfill for [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
+ * necessary for inert polyfill.
+ */
+import 'mutationobserver-shim';
+
+/**
  * Polyfill for [Node.contains](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)
  * necessary for inert polyfill.
  */


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
The inert polyfill has a dependency on MutationObserver, which is not supported by IE10. So we must add that polyfill to terra-polyfill.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
