### PR TITLE
generateNavigationConfig converts windows file paths to linux style f…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ Cerner Corporation
 - Avinash Gupta [@avinashg1994]
 - Saket Bajaj [@saket2403]
 - Pranav Agarwal [@pranav300]
+- Mackenzie Revoyr [@revoyrm]
 
 [@mjhenkes]: https://github.com/mjhenkes
 [@tbiethman]: https://github.com/tbiethman
@@ -27,3 +28,4 @@ Cerner Corporation
 [@avinashg1994]: https://github.com/avinashg1994
 [@saket2403]: https://github.com/saket2403
 [@pranav300]: https://github.com/pranav300
+[@revoyrm]: https://github.com/revoyrm

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "lerna": "^3.16.4",
     "link-parent-bin": "^1.0.0",
     "loader-runner": "^4.1.0",
-    "postcss": "^8.2.10",
+    "postcss": "8.3.11",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-intl": "^2.9.0",

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed
+  * Add support for Windows file path separator.
+
 ## 7.4.0 - (October 28, 2021)
 
 * Fixed

--- a/packages/terra-dev-site/src/webpack/loaderUtils/configHelpers.js
+++ b/packages/terra-dev-site/src/webpack/loaderUtils/configHelpers.js
@@ -80,12 +80,20 @@ const parseExtension = filePath => {
   });
 };
 
+/**
+ * Returns a linux style file path.
+ *
+* @param {*} filePath A string representing the directory path of the file.
+*/
+const formatPath = filePath => filePath.replace(/\\/g, '/');
+
 const configHelpers = {
   startCase,
   pageTypes,
   getNamespace,
   getRoutes,
   parseExtension,
+  formatPath,
 };
 
 module.exports = configHelpers;

--- a/packages/terra-dev-site/src/webpack/loaderUtils/generateNavigationConfig.js
+++ b/packages/terra-dev-site/src/webpack/loaderUtils/generateNavigationConfig.js
@@ -7,6 +7,7 @@ const {
   getNamespace,
   getRoutes,
   parseExtension,
+  formatPath,
 } = require('./configHelpers');
 
 /**
@@ -182,7 +183,7 @@ const addWatchContentDirectories = ({
     return;
   }
 
-  const processPath = process.cwd();
+  const processPath = formatPath(process.cwd());
 
   if (isLernaMonoRepo) {
     glob.sync(`${processPath}/packages/*/${sourceFolder}/${contentDirectory}`).forEach(dir => { addContextDependency(`${dir}/`); });
@@ -201,7 +202,7 @@ const getSearchPatterns = ({
   isLernaMonoRepo,
   contentDirectory,
 }) => {
-  const processPath = process.cwd();
+  const processPath = formatPath(process.cwd());
   const typesGlob = pageTypes(primaryNavigationItems).join(',');
   const typesRegex = pageTypes(primaryNavigationItems).map((type) => `/${type}`).join('|');
 
@@ -302,7 +303,7 @@ const generatePagesConfig = ({
     if (item.additionalContent) {
       item.additionalContent.forEach((content) => {
         filePaths.push({
-          filePath: content.filePath,
+          filePath: formatPath(content.filePath),
           entryPoint: `/${content.label}.${item.contentExtension}${path.extname(content.filePath)}`,
         });
       });

--- a/packages/terra-dev-site/tests/jest/webpack/loaderUtils/configHelpers.test.js
+++ b/packages/terra-dev-site/tests/jest/webpack/loaderUtils/configHelpers.test.js
@@ -34,3 +34,12 @@ describe('getNamespace', () => {
     expect(result).toEqual('@cerner/testing');
   });
 });
+
+describe('formatPath', () => {
+  it('returns fully linux style file path', () => {
+    const testWindowsPath = '\\windowsFilePath\\joined/with/linux/path';
+    const result = configHelpers.formatPath(testWindowsPath);
+
+    expect(result).toEqual('/windowsFilePath/joined/with/linux/path');
+  });
+});


### PR DESCRIPTION
…ile paths

### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

This is a proxy for #281 

> Changes required to generate development site on windows devices.


<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #280 

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing

> I ran npm run compile and moved the generated lib folder into the node modules terra dev site folder in my media-viewer-js project and ran npm start in windows and in wsl to make sure this worked in both places.
> 
> If there's a way to deploy this change so I can get it via an npm install, I will test it that way.

### Additional Details

> My changes remove the double backslash in the windows file paths and replaces each instance with one forward slash. This works on both windows and linux development environments.

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
