### PR TITLE
Updated breakpoints documentation to replace `isBreakpointActiveForSi…

### DIFF
--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Updated breakpoints documentation to replace `isBreakpointActiveForSize` with `breakpointIsActiveForSize`.
+
 ## 1.52.1 - (December 3, 2021)
 
 * Fixed

--- a/packages/terra-application/src/terra-dev-site/app/utilities.2/Breakpoints.app.mdx
+++ b/packages/terra-application/src/terra-dev-site/app/utilities.2/Breakpoints.app.mdx
@@ -6,7 +6,7 @@ that can be used to detect and respond to breakpoint changes.
 ## Usage
 
 ```jsx
-import breakpoints, { activeBreakpointForSize, isBreakpointActiveForSize } from 'terra-application/lib/breakpoints';
+import breakpoints, { activeBreakpointForSize, breakpointIsActiveForSize } from 'terra-application/lib/breakpoints';
 ```
 
 ### `breakpoints`
@@ -35,28 +35,28 @@ console.log(activeBreakpointForSize(1300)); // 'huge'
 console.log(activeBreakpointForSize(1500)); // 'enormous'
 ```
 
-### `isBreakpointActiveForSize(breakpointName, widthValue)`
+### `breakpointIsActiveForSize(breakpointName, widthValue)`
 
-`isBreakpointActiveForSize` will return a boolean value indicating whether or not the given breakpoint name is active for the width value.
+`breakpointIsActiveForSize` will return a boolean value indicating whether or not the given breakpoint name is active for the width value.
 
 > Note that since the breakpoints are defined as minimum values, a breakpoint will be determined to be active
 > if the width value is larger than the defined minimum, even if the width value is included in a higher breakpoint range.
 
 ```jsx
-console.log(isBreakpointActiveForSize('tiny', 300));      // true
-console.log(isBreakpointActiveForSize('tiny', 544));      // true
-console.log(isBreakpointActiveForSize('tiny', 800));      // true
-console.log(isBreakpointActiveForSize('tiny', 1000));     // true
+console.log(breakpointIsActiveForSize('tiny', 300));      // true
+console.log(breakpointIsActiveForSize('tiny', 544));      // true
+console.log(breakpointIsActiveForSize('tiny', 800));      // true
+console.log(breakpointIsActiveForSize('tiny', 1000));     // true
 
-console.log(isBreakpointActiveForSize('medium', 300));    // false
-console.log(isBreakpointActiveForSize('medium', 544));    // false
-console.log(isBreakpointActiveForSize('medium', 800));    // true
-console.log(isBreakpointActiveForSize('medium', 1500));   // true
+console.log(breakpointIsActiveForSize('medium', 300));    // false
+console.log(breakpointIsActiveForSize('medium', 544));    // false
+console.log(breakpointIsActiveForSize('medium', 800));    // true
+console.log(breakpointIsActiveForSize('medium', 1500));   // true
 
-console.log(isBreakpointActiveForSize('enormous', 300));  // false
-console.log(isBreakpointActiveForSize('enormous', 544));  // false
-console.log(isBreakpointActiveForSize('enormous', 800));  // false
-console.log(isBreakpointActiveForSize('enormous', 1500)); // true
+console.log(breakpointIsActiveForSize('enormous', 300));  // false
+console.log(breakpointIsActiveForSize('enormous', 544));  // false
+console.log(breakpointIsActiveForSize('enormous', 800));  // false
+console.log(breakpointIsActiveForSize('enormous', 1500)); // true
 ```
 
 ### Media Queries


### PR DESCRIPTION
…ze` with `breakpointIsActiveForSize`.

### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Updated breakpoints documentation to replace `isBreakpointActiveForSize` with `breakpointIsActiveForSize`.
This change is similar to https://github.com/cerner/terra-core/pull/3297.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
