### PR TITLE
Make node version open-ended

### DIFF
--- a/packages/terra-application-docs/CHANGELOG.md
+++ b/packages/terra-application-docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.7.0 - (February 14, 2022)
+
 * Changed
   * Revert limiting upper Node version to 14.
 

--- a/packages/terra-application-docs/CHANGELOG.md
+++ b/packages/terra-application-docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert limiting upper Node version to 14.
+
 ## 2.6.0 - (February 8, 2022)
 
 * Added

--- a/packages/terra-application-docs/README.md
+++ b/packages/terra-application-docs/README.md
@@ -5,6 +5,10 @@
 
 Contains documentation for packages in the terra-application monorepo
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
+
 ## Versioning
 
 terra-application-docs is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/terra-application-docs/package.json
+++ b/packages/terra-application-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-application-docs",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Contains documentation for packages in the terra-application monorepo",
   "main": "index.js",
   "publishConfig": {
@@ -35,7 +35,7 @@
     "precompile": "rm -rf lib"
   },
   "dependencies": {
-    "@cerner/terra-dev-site": "^7.5.0",
+    "@cerner/terra-dev-site": "^7.6.0",
     "@cerner/terra-docs": "^1.0.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",

--- a/packages/terra-application-docs/package.json
+++ b/packages/terra-application-docs/package.json
@@ -26,7 +26,7 @@
     "src"
   ],
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-application",
   "scripts": {

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 7.6.0 - (February 14, 2022)
+
 * Changed
   * Revert limiting upper Node version to 14.
 

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert limiting upper Node version to 14.
+
 ## 7.5.0 - (February 8, 2022)
 
 * Added

--- a/packages/terra-dev-site/README.md
+++ b/packages/terra-dev-site/README.md
@@ -26,6 +26,10 @@ npm install --save-dev @cerner/terra-dev-site
 npm install --save-dev terra-application react-dom@^16.8.5 react@^16.8.5 webpack@^5
 ```
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
+
 ## Versioning
 
 terra-dev-site is considered to be stable and will follow [SemVer](https://semver.org/) for versioning.

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -3,7 +3,7 @@
   "version": "7.5.0",
   "description": "Dynamically builds a react-hash-routed site based on site configuration, navigation configuration and component configuration.",
   "engines": {
-    "node": "^10.0.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10"
   },
   "main": "index.js",
   "publishConfig": {

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-dev-site",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "description": "Dynamically builds a react-hash-routed site based on site configuration, navigation configuration and component configuration.",
   "engines": {
     "node": ">=10"
@@ -45,7 +45,7 @@
     "wdio": "npm run wdio-default && npm run wdio-lowlight && npm run wdio-fusion"
   },
   "dependencies": {
-    "@cerner/terra-polyfill": "^1.1.0",
+    "@cerner/terra-polyfill": "^1.2.0",
     "@jsdevtools/rehype-url-inspector": "^2.0.2",
     "@mdx-js/loader": "^1.4.5",
     "@mdx-js/mdx": "^1.5.0",

--- a/packages/terra-polyfill/CHANGELOG.md
+++ b/packages/terra-polyfill/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.2.0 - (February 14, 2022)
+
 * Changed
   * Revert limiting upper Node version to 14.
 

--- a/packages/terra-polyfill/CHANGELOG.md
+++ b/packages/terra-polyfill/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Changed
+  * Revert limiting upper Node version to 14.
+
 ## 1.1.0 - (February 8, 2022)
 
 * Added

--- a/packages/terra-polyfill/README.md
+++ b/packages/terra-polyfill/README.md
@@ -5,6 +5,10 @@
 
 This package contains polyfills to support the minimum requirements and commonly used features of [terra-application](https://www.npmjs.org/package/@cerner/terra-application) and its consumers.
 
+## Node version support
+
+This package was developed and tested using Node 10 up to Node 14. Consumers using Node 16 or greater are advised to use it at their own risk since those versions are not officially supported due to lack of thorough testing.
+
 ## Versioning
 
 terra-polyfill is considered to be stable and will follow [SemVer](http://semver.org/) for versioning.

--- a/packages/terra-polyfill/package.json
+++ b/packages/terra-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerner/terra-polyfill",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This package contains polyfills to support the minimum requirements and commonly used features of terra-application and its consumers.",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/terra-polyfill/package.json
+++ b/packages/terra-polyfill/package.json
@@ -26,7 +26,7 @@
     "lib"
   ],
   "engines": {
-    "node": "^10.13.0 || ^12.0.0 || ^14.0.0"
+    "node": ">=10.13.0"
   },
   "homepage": "https://github.com/cerner/terra-application",
   "scripts": {


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

- PR #289 close-ended the Node version up to 14 and this affected consumers on 16+.
- Reverted the Node version to support versions greater than 14.
- Added doc for Node version support. 
- Publish these packages

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
