### PR TITLE
Added Date Time Format Polyfill to support DateTimeFormat() Options in IE 10

### DIFF
--- a/packages/terra-polyfill/CHANGELOG.md
+++ b/packages/terra-polyfill/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added
+  * Added `@formatjs/intl-datetimeformat` polyfill to support date-time functions in ie 10.
+
 ## 1.2.0 - (February 14, 2022)
 
 * Changed

--- a/packages/terra-polyfill/package.json
+++ b/packages/terra-polyfill/package.json
@@ -36,6 +36,9 @@
   },
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "^8.0.0",
+    "@formatjs/intl-datetimeformat": "^5.0.2",
+    "@formatjs/intl-getcanonicallocales": "^1.9.2",
+    "@formatjs/intl-locale": "^2.4.47",
     "abortcontroller-polyfill": "^1.7.3",
     "core-js": "^3.15.2",
     "intl": "^1.2.5",

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -47,11 +47,3 @@ import './polyfills/inert-polyfill';
  * Polyfill for [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
  */
 import './polyfills/intl-polyfill';
-
-/**
- * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
- * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
- */
-import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
-
-export { intlDateTimeFormatPolyfill };

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -47,3 +47,11 @@ import './polyfills/inert-polyfill';
  * Polyfill for [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
  */
 import './polyfills/intl-polyfill';
+
+/**
+ * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+ * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
+ */
+import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill;
+
+export { intlDateTimeFormatPolyfill };

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -52,6 +52,6 @@ import './polyfills/intl-polyfill';
  * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
  * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
  */
-import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill;
+import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
 
 export { intlDateTimeFormatPolyfill };

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -48,10 +48,10 @@ import './polyfills/inert-polyfill';
  */
 import './polyfills/intl-polyfill';
 
-/**
- * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
- * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
- */
-import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
+// /**
+//  * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+//  * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
+//  */
+// import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
 
-export { intlDateTimeFormatPolyfill };
+// export { intlDateTimeFormatPolyfill };

--- a/packages/terra-polyfill/src/index.js
+++ b/packages/terra-polyfill/src/index.js
@@ -48,10 +48,10 @@ import './polyfills/inert-polyfill';
  */
 import './polyfills/intl-polyfill';
 
-// /**
-//  * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
-//  * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
-//  */
-// import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
+/**
+ * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+ * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
+ */
+import intlDateTimeFormatPolyfill from './polyfills/intlDateTimeFormatPolyfill';
 
-// export { intlDateTimeFormatPolyfill };
+export { intlDateTimeFormatPolyfill };

--- a/packages/terra-polyfill/src/polyfills/intlDateTimeFormatPolyfill.js
+++ b/packages/terra-polyfill/src/polyfills/intlDateTimeFormatPolyfill.js
@@ -1,0 +1,11 @@
+/* eslint-disable global-require, import/no-dynamic-require */
+import '@formatjs/intl-getcanonicallocales/polyfill';
+import '@formatjs/intl-locale/polyfill';
+
+/* `@formatjs/intl-datetimeformat/polyfill` requires `@formatjs/intl-getcanonicallocales` and `@formatjs/intl-locale/polyfil` https://formatjs.io/docs/polyfills/intl-datetimeformat */
+function intlDateTimeFormatPolyfill(locale) {
+  require('@formatjs/intl-datetimeformat/polyfill');
+  require(`@formatjs/intl-datetimeformat/locale-data/${locale}`);
+}
+
+export default intlDateTimeFormatPolyfill;

--- a/packages/terra-polyfill/src/polyfills/intlDateTimeFormatPolyfill.js
+++ b/packages/terra-polyfill/src/polyfills/intlDateTimeFormatPolyfill.js
@@ -1,4 +1,8 @@
 /* eslint-disable global-require, import/no-dynamic-require */
+/**
+ * Polyfill for [Intl.DateTimeFormat() Options parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat).
+ * `options` parameter of Date and Intl functions are not supported in IE10 hence adding this polyfill to provide support for `options` parameter in IE10. : https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility
+ */
 import '@formatjs/intl-getcanonicallocales/polyfill';
 import '@formatjs/intl-locale/polyfill';
 


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

`options` parameter of Intl.DatetimeFormat and Date().toLocaleDateString() methods are not supported in IE 10.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#browser_compatibility

To support this method `@formatjs/intl-datetimeformat` polyfill has been included in terra-polyfill. 
`@formatjs/intl-datetimeformat` has been added as a helper function terra-polyfill instead of default imports like other polyfills of terra-polyfill.

Since this polyfill is mostly needed only for the consumers supporting IE10. It is being shipped as helper function consumer would need to pass in the required locale string to consume the date-time-format polyfill.

`@formatjs/intl-datetimeformat` polyfill requires explicit import of locales to work. adding import for all the locales by default increased page load time in IE 10 browsers hence decided to load the specific locale by accepting locale string as a parameter.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
