### PR TITLE
Fixes multiple Id `inert-style` issue

### DIFF
--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed
+  * updated condition statement added to check `inert` polyfill is required.
+  * updated `wicg-inert` to latest version.
+
 ## 2.0.1 - (June 8, 2022)
 
 * Minor dependency bump

--- a/packages/terra-application/package.json
+++ b/packages/terra-application/package.json
@@ -80,7 +80,7 @@
     "terra-toolbar": "^1.22.0",
     "terra-visually-hidden-text": "^2.31.0",
     "uuid": "^3.0.0",
-    "wicg-inert": "^3.0.2"
+    "wicg-inert": "3.1.2"
   },
   "devDependencies": {
     "@cerner/terra-enzyme-intl": "^4.0.0"

--- a/packages/terra-application/src/application-base/private/initializeInert.js
+++ b/packages/terra-application/src/application-base/private/initializeInert.js
@@ -9,12 +9,13 @@ import '../../utils/polyfills/_matches-polyfill';
  * across the framework's supported browsers, so a polyfill is added on an as-need basis to ensure feature parity.
  */
 function initializeInert() {
+  const inertId = 'inert-style';
   /**
    * We manually check whether the inert polyfill is necessary so as to
    * not to add the inert style link unnecessarily.
    */
   // eslint-disable-next-line no-prototype-builtins
-  if (Element.prototype.hasOwnProperty('inert')) {
+  if (HTMLElement.prototype.hasOwnProperty('inert') || document.getElementById(inertId)) {
     return;
   }
 
@@ -24,7 +25,7 @@ function initializeInert() {
    * https://github.com/WICG/inert#strict-content-security-policy
    */
   const inertStyleLink = document.createElement('link');
-  inertStyleLink.id = 'inert-style';
+  inertStyleLink.id = inertId;
 
   const styleLinkParent = document.head || document.body;
   styleLinkParent.appendChild(inertStyleLink);

--- a/packages/terra-polyfill/CHANGELOG.md
+++ b/packages/terra-polyfill/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed
+  * updated condition statement added to check `inert` polyfill is required.
+  * updated `wicg-inert` to latest version.
+
 ## 1.3.0 - (June 7, 2022)
 
 * Added

--- a/packages/terra-polyfill/package.json
+++ b/packages/terra-polyfill/package.json
@@ -45,6 +45,6 @@
     "mutationobserver-shim": "<=0.3.3",
     "regenerator-runtime": "^0.13.9",
     "whatwg-fetch": "^3.6.2",
-    "wicg-inert": "^3.0.2"
+    "wicg-inert": "3.1.2"
   }
 }

--- a/packages/terra-polyfill/src/polyfills/inert-polyfill.js
+++ b/packages/terra-polyfill/src/polyfills/inert-polyfill.js
@@ -7,7 +7,7 @@ import './inertStyles.scss';
  */
 
 // eslint-disable-next-line no-prototype-builtins
-if (!Element.prototype.hasOwnProperty('inert')) {
+if (!HTMLElement.prototype.hasOwnProperty('inert') && !document.getElementById('inert-style')) {
   // We create a link whose presence indicates that the polyfill should not create
   // inline inert styles in the document. This prevents certain issues with strict CSP settings:
   // https://github.com/WICG/inert#strict-content-security-policy


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
`Element.prototype.hasOwnProperty('inert')` is included in application-base and inert-polyfill of `@cerner/terra-polyfill` to check if `inert` polyfill is required. In Latest release of `wicg-inert`-`3.1.2` `Element` has been replaced with `HTMLElement` This was causing accessibility test failures across the consuming projects.

https://github.com/WICG/inert/pull/182/files

This PR locks `wicg-inert` version to prevent disruptive test failures in future. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
