### PR TITLE
terra-dev-site page height update

### DIFF
--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Changed
+  * Update dev-site v7. 
   * Update wdio snapshot to fix build.
 
 ## 8.1.0 - (June 22, 2022)

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+* Fixed
+  * Fixed clipping issue of test pages in dev-site v7.
+
 * Changed
-  * Update dev-site v7. 
   * Update wdio snapshot to fix build.
 
 ## 8.1.0 - (June 22, 2022)

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed
-  * Fixed clipping issue of test pages in dev-site v7.
+  * Fixed clipping issue of test pages in dev-site.
 
 * Changed
   * Update wdio snapshot to fix build.

--- a/packages/terra-dev-site/src/content/ContentLoaded.module.scss
+++ b/packages/terra-dev-site/src/content/ContentLoaded.module.scss
@@ -2,9 +2,10 @@
 @import './orion-fusion-theme/ContentLoaded.module';
 
 :local {
-  .dev-site-content{
+  .dev-site-content {
     height: 100%;
   }
+  
   .scroll {
     overflow: auto;
     -webkit-overflow-scrolling: touch;

--- a/packages/terra-dev-site/src/content/ContentLoaded.module.scss
+++ b/packages/terra-dev-site/src/content/ContentLoaded.module.scss
@@ -2,8 +2,10 @@
 @import './orion-fusion-theme/ContentLoaded.module';
 
 :local {
-  .scroll {
+  .dev-site-content{
     height: 100%;
+  }
+  .scroll {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     position: relative;

--- a/packages/terra-dev-site/src/content/_ContentLoaded.jsx
+++ b/packages/terra-dev-site/src/content/_ContentLoaded.jsx
@@ -46,6 +46,7 @@ const ContentLoaded = ({ children, type, isScrollContainer }) => {
       className={
         cx(
           theme.className,
+          'dev-site-content',
           {
             markdown: ['md', 'mdx'].includes(type),
             scroll: isScrollContainer,

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -17,6 +17,7 @@
     min-height: calc(100% - 30px);
     overflow: hidden;
     padding: 0 10px 10px;
+    height: 100%;
 
     @include terra-mq-medium-up {
       min-width: 682px;

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -14,10 +14,10 @@
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
+    height: 100%;
     min-height: calc(100% - 30px);
     overflow: hidden;
     padding: 0 10px 10px;
-    height: 100%;
 
     @include terra-mq-medium-up {
       min-width: 682px;

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -14,7 +14,7 @@
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: calc(100% - 30px);
     min-height: calc(100% - 30px);
     overflow: hidden;
     padding: 0 10px 10px;


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->

Changes in terra-dev-site were introduced starting in v7, and persisted in v8, that caused clipping issues for some dev-site testing pages. This fix resolves the clipping of those pages.

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->

Closes UXPLATFORM-6906


### Deployment Link
<!---Include the deployment link, if applicable. -->
Examples of corrected test pages:
- https://terra-applic-dev-site-u-9t74bb.herokuapp.com/tests/terra-application/application-navigation/private/application-navigation/application-navigation
- https://terra-applic-dev-site-u-9t74bb.herokuapp.com/tests/terra-application/application-navigation/private/application-navigation/tabs
- https://terra-applic-dev-site-u-9t74bb.herokuapp.com/tests/terra-application/application-navigation/private/application-navigation/application-notifications



### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->
