### PR TITLE
Fixes Scroll and Cliping issues of dev-site v7

### DIFF
--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Fixed
-  * Fixed clipping issue of test pages in dev-site.
+  * Fixed clipping issue of test pages on dev-site.
+  * Fixed scroll issue of doc pages with longer content.
 
 * Changed
   * Update wdio snapshot to fix build.

--- a/packages/terra-dev-site/src/content/ContentLoaded.module.scss
+++ b/packages/terra-dev-site/src/content/ContentLoaded.module.scss
@@ -4,8 +4,8 @@
 :local {
   .dev-site-content {
     flex: 1 1 auto;
-    overflow: hidden;
     height: 100%;
+    overflow: hidden;
     width: 100%;
   }
 

--- a/packages/terra-dev-site/src/content/ContentLoaded.module.scss
+++ b/packages/terra-dev-site/src/content/ContentLoaded.module.scss
@@ -3,14 +3,15 @@
 
 :local {
   .dev-site-content {
+    flex: 1 1 auto;
+    overflow: hidden;
     height: 100%;
+    width: 100%;
   }
 
   .scroll {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    position: relative;
-    width: 100%;
   }
 }
 

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -13,10 +13,10 @@
     border-top: 1px solid #eeefee;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     display: flex;
-    flex-direction: column;
     flex: 1 1 auto;
-    margin-top: 15px;
+    flex-direction: column;
     margin-bottom: 15px;
+    margin-top: 15px;
     padding: 0 10px 10px;
 
     @include terra-mq-medium-up {

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -14,9 +14,9 @@
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
-    height: calc(100% - 30px);
-    min-height: calc(100% - 30px);
-    overflow: hidden;
+    flex: 1 1 auto;
+    margin-top: 15px;
+    margin-bottom: 15px;
     padding: 0 10px 10px;
 
     @include terra-mq-medium-up {

--- a/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
@@ -2,24 +2,14 @@
 
 :local {
   .card-layout {
-    display: block;
+    display: flex;
+    flex-direction: column;
     height: 100%;
     outline: none;
     overflow-x: auto;
     overflow-y: auto;
     padding: 0 15px;
     position: relative;
-  }
-
-  // Firefox bug with overflow content and padding-bottom.
-  // Without this ::after content, the card will not have appropriate
-  // bottom padding when it overflows.
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1517825
-  .card-layout::before,
-  .card-layout::after {
-    content: '';
-    display: block;
-    height: 15px;
   }
 
   .card-container:not(:first-child) {

--- a/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
@@ -13,6 +13,6 @@
   }
 
   .card-container:not(:first-child) {
-    margin-top: 15px;
+    margin-top: -15px;
   }
 }


### PR DESCRIPTION
### Summary
<!--- Summarize and explain the reason behind these code changes. What are the changes, and why are they necessary? -->
This PR Patchs Back the code changes made on PR #310 https://github.com/cerner/terra-application/pull/310 for fixing height issue with dev-site v7.

Page with longer content was clipped to height of card ( container of dev-site content ) 

<img width="1391" alt="Screen Shot 2022-11-17 at 4 30 44 PM" src="https://user-images.githubusercontent.com/12869809/202430473-a3f3b85d-9bb3-4e11-828b-81986e498de7.png">

flex box styles have been added for dev-site wrappers to allow content to grow without getting clipped. 

<!--- Include any issue addressed by this pull request. -->
<!--- Example: Closes #45 -->
Closes #UXPLATFORM-6906

### Deployment Link
<!---Include the deployment link, if applicable. -->
https://terra-applic-devsite-v7-1iourz.herokuapp.com/

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

<!--
*Before publishing*

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

Thank you for contributing to Terra.
@cerner/terra
