### PR TITLE
[terra-dev-site] fix card scrolling in terra-dev-site

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ Cerner Corporation
 - Saket Bajaj [@saket2403]
 - Pranav Agarwal [@pranav300]
 - Mackenzie Revoyr [@revoyrm]
+- Sam Bao [@sambao21]
 
 [@mjhenkes]: https://github.com/mjhenkes
 [@tbiethman]: https://github.com/tbiethman
@@ -29,3 +30,4 @@ Cerner Corporation
 [@saket2403]: https://github.com/saket2403
 [@pranav300]: https://github.com/pranav300
 [@revoyrm]: https://github.com/revoyrm
+[@sambao21]: https://github.com/sambao21

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -3,13 +3,8 @@
 ## Unreleased
 
 * Fixed
-<<<<<<< HEAD
-  * Fixed clipping issue of test pages in dev-site.
-  * Fixed scrolling on dev-site
-=======
   * Fixed clipping issue of test pages on dev-site.
   * Fixed scroll issue of doc pages with longer content.
->>>>>>> dbcb3573 (Fixes Scroll and Cliping issues of dev-site v7 (#316))
 
 * Changed
   * Update wdio snapshot to fix build.

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed
   * Fixed clipping issue of test pages in dev-site.
+  * Fixed scrolling on dev-site
 
 * Changed
   * Update wdio snapshot to fix build.

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -3,8 +3,13 @@
 ## Unreleased
 
 * Fixed
+<<<<<<< HEAD
   * Fixed clipping issue of test pages in dev-site.
   * Fixed scrolling on dev-site
+=======
+  * Fixed clipping issue of test pages on dev-site.
+  * Fixed scroll issue of doc pages with longer content.
+>>>>>>> dbcb3573 (Fixes Scroll and Cliping issues of dev-site v7 (#316))
 
 * Changed
   * Update wdio snapshot to fix build.

--- a/packages/terra-dev-site/src/content/ContentLoaded.module.scss
+++ b/packages/terra-dev-site/src/content/ContentLoaded.module.scss
@@ -3,14 +3,15 @@
 
 :local {
   .dev-site-content {
+    flex: 1 1 auto;
     height: 100%;
+    overflow: hidden;
+    width: 100%;
   }
   
   .scroll {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
-    position: relative;
-    width: 100%;
   }
 }
 

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -16,7 +16,7 @@
     flex-direction: column;
     height: calc(100% - 30px);
     min-height: calc(100% - 30px);
-    overflow: hidden;
+    overflow: auto;
     padding: 0 10px 10px;
 
     @include terra-mq-medium-up {

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -13,10 +13,16 @@
     border-top: 1px solid #eeefee;
     box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
     display: flex;
+    flex: 1 1 auto;
     flex-direction: column;
+<<<<<<< HEAD
     height: calc(100% - 30px);
     min-height: calc(100% - 30px);
     overflow: auto;
+=======
+    margin-bottom: 15px;
+    margin-top: 15px;
+>>>>>>> dbcb3573 (Fixes Scroll and Cliping issues of dev-site v7 (#316))
     padding: 0 10px 10px;
 
     @include terra-mq-medium-up {

--- a/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/Card.module.scss
@@ -15,14 +15,8 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-<<<<<<< HEAD
-    height: calc(100% - 30px);
-    min-height: calc(100% - 30px);
-    overflow: auto;
-=======
     margin-bottom: 15px;
     margin-top: 15px;
->>>>>>> dbcb3573 (Fixes Scroll and Cliping issues of dev-site v7 (#316))
     padding: 0 10px 10px;
 
     @include terra-mq-medium-up {

--- a/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
+++ b/packages/terra-dev-site/src/pages/page/layouts/CardLayout.module.scss
@@ -2,7 +2,8 @@
 
 :local {
   .card-layout {
-    display: block;
+    display: flex;
+    flex-direction: column;
     height: 100%;
     outline: none;
     overflow-x: auto;
@@ -11,18 +12,7 @@
     position: relative;
   }
 
-  // Firefox bug with overflow content and padding-bottom.
-  // Without this ::after content, the card will not have appropriate
-  // bottom padding when it overflows.
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1517825
-  .card-layout::before,
-  .card-layout::after {
-    content: '';
-    display: block;
-    height: 15px;
-  }
-
   .card-container:not(:first-child) {
-    margin-top: 15px;
+    margin-top: -15px;
   }
 }


### PR DESCRIPTION
### Summary
The card container that displays content wasn't scrolling for me, and by setting terra-dev-site card overflow from hidden to 

### Testing
Loaded up the terra-dev-site in Chrome and Firefox before and after the fix to show that it was not scrolling before, and it does after changing overflow to auto.

Before:
Chrome:
![Kapture 2022-12-19 at 16 05 35](https://user-images.githubusercontent.com/253647/208534384-a0694a0a-6912-4339-a4b4-631bacfa9c7d.gif)

Firefox:
![Kapture 2022-12-19 at 16 06 49](https://user-images.githubusercontent.com/253647/208535117-e9008b26-2f3e-4780-8684-2a9170726159.gif)

After:
Chrome:
![Kapture 2022-12-19 at 16 02 08](https://user-images.githubusercontent.com/253647/208532736-7316c849-cad4-4319-9343-603560515747.gif)

Firefox:
![Kapture 2022-12-19 at 16 04 07](https://user-images.githubusercontent.com/253647/208533580-b157b4a9-6494-44eb-8fa6-33a3f4aa23aa.gif)



