### PR TITLE
uuid locked to v8.2.0

### DIFF
--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changed
   * Updated jest snapshots for terra-icon and terra-button changes.
   * Updated size explanations for ModalManager managed by DisclosureManagerContext.
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 * Added
   * Added user action utility button.

--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changed
   * Updated jest snapshots for terra-icon and terra-button changes.
   * Updated size explanations for ModalManager managed by DisclosureManagerContext.
-  * Updated `uuid` to `v8.2.0` for consistency with other components.
+  * Updated `uuid` to `8.2.0` for consistency with other components.
 
 * Added
   * Added user action utility button.

--- a/packages/terra-application/package.json
+++ b/packages/terra-application/package.json
@@ -79,7 +79,7 @@
     "terra-theme-provider": "^4.0.0",
     "terra-toolbar": "^1.22.0",
     "terra-visually-hidden-text": "^2.31.0",
-    "uuid": "^8.3.2",
+    "uuid": "8.2.0",
     "wicg-inert": "3.1.2"
   },
   "devDependencies": {

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed
   * Updated jest snapshot for terra-icon and terra-button changes.
   * Updated wdio snapshot to fix build.
-  * Updated `uuid` to `v8.2.0` for consistency with other components.
+  * Updated `uuid` to `8.2.0` for consistency with other components.
 
 ## 8.1.0 - (June 22, 2022)
 

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed
   * Updated jest snapshot for terra-icon and terra-button changes.
   * Updated wdio snapshot to fix build.
-  * Updated `uuid` to `v8` for consistency with other components.
+  * Updated `uuid` to `v8.2.0` for consistency with other components.
 
 ## 8.1.0 - (June 22, 2022)
 

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -83,7 +83,7 @@
     "terra-mixins": "^1.33.0",
     "terra-search-field": "^3.13.0",
     "terra-status-view": "^4.10.0",
-    "uuid": "^8.3.2"
+    "uuid": "8.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.5",


### PR DESCRIPTION
### Summary
Per test issues caused to some projects that use terra-toolkit by stringify updated in uuid v8.3.0, the uuid version has been locked to 8.2.0

### Testing
This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review
