### PR TITLE
Lock uuid dependency to 7.0.3

### DIFF
--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changed
   * Updated jest snapshots for terra-icon and terra-button changes.
   * Updated size explanations for ModalManager managed by DisclosureManagerContext.
-  * Updated `uuid` to `8.2.0` for consistency with other components.
+  * Locked `uuid` to `7.0.3` for consistency with other Terra packages.
 
 * Added
   * Added user action utility button.

--- a/packages/terra-application/package.json
+++ b/packages/terra-application/package.json
@@ -79,7 +79,7 @@
     "terra-theme-provider": "^4.0.0",
     "terra-toolbar": "^1.22.0",
     "terra-visually-hidden-text": "^2.31.0",
-    "uuid": "8.2.0",
+    "uuid": "7.0.3",
     "wicg-inert": "3.1.2"
   },
   "devDependencies": {

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed
   * Updated jest snapshot for terra-icon and terra-button changes.
   * Updated wdio snapshot to fix build.
-  * Updated `uuid` to `8.2.0` for consistency with other components.
+  * Locked `uuid` to `7.0.3` for consistency with other Terra packages.
 
 ## 8.1.0 - (June 22, 2022)
 

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -83,7 +83,7 @@
     "terra-mixins": "^1.33.0",
     "terra-search-field": "^3.13.0",
     "terra-status-view": "^4.10.0",
-    "uuid": "8.2.0"
+    "uuid": "7.0.3"
   },
   "peerDependencies": {
     "react": "^16.8.5",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

This PR locks `uuid` to `7.0.3` for consistency across Terra packages.


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->



---

Thank you for contributing to Terra.
@cerner/terra
