### PR TITLE
browser locale fix for IE

### DIFF
--- a/packages/terra-application/src/application-base/private/getBrowserLocale.js
+++ b/packages/terra-application/src/application-base/private/getBrowserLocale.js
@@ -50,6 +50,11 @@ const getBrowserLocale = () => {
     return preferredLocale;
   }
 
+  /* for IE support, as languages and language in IE return undefined, and userLanguage and browserLanguage return "en-US" */
+  if (isSupported(navigator.systemLanguage)) {
+    return navigator.systemLanguage;
+  }
+
   if (isSupported(navigator.language)) {
     return navigator.language;
   }


### PR DESCRIPTION
### Summary
This  PR introduces changes to `getBrowserLocale` method to accommodate the way IE navigator works with browser language. 

### Why the change is needed
It has been reported that if the browser language is set to a different language, it translates correctly in all browsers but IE. The issue was pointed out to be coming from current implementation of the browser language being obtained from the navigator languages properties, which for IE differs from the rest of the browsers. Following tests indicated in favor of that:

I changed the language in IE browser from English to German and console logged the navigator language properties. I observed following:

```
navigator.languages: undefined
navigator.language: undefined
navigator.userLanguage: "en-US"
navigator.browserLanguage: "en-US"
navigator.systemLanguage: "de-DE"
```
It means that for IE the only navigator property that reflects the current browser language is `navigator.systemLanguage`. 
The current implementation of `getBrowserLocale` method does not use `navigator.systemLanguage` property, hence error in IE. It does work good for the rest of the browsers though, as they take the language from navigator languages array. I tested it by changing the language from English to German in Chrome, Firefox, Safari and Edge and received following console output:

```
navigator.languages: Array(1)['de']
navigator.language: 'de'
navigator.userLanguage: undefined
navigator.browserLanguage: undefined
navigator.systemLanguage: undefined
```

### Testing
This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

Following testing have been done for Chrome, Firefox, Safari and Edge:
1. The language of these browsers have been changed to supported locale (German language), the console.log for getBrowserLocale method returning result was correctly set to 'de' (German):

<img width="1732" alt="Screenshot 2023-08-07 at 11 08 49 AM" src="https://github.com/cerner/terra-application/assets/119358186/140443e0-15fe-4e0b-a6b3-7deef358539d">

2. The language has been changed to not supported locale (Ukrainian language), the console.log for getBrowserLocale method returning result was correctly set to fall-back locale 'en' (English).

<img width="1733" alt="Screenshot 2023-08-07 at 11 15 24 AM" src="https://github.com/cerner/terra-application/assets/119358186/ac49e493-0738-4d8a-827b-646e9d59cce6">

3. The browser language was set to English, the console.log for getBrowserLocale method returning result was correctly set to 'en' (English).

<img width="1734" alt="Screenshot 2023-08-07 at 11 25 54 AM" src="https://github.com/cerner/terra-application/assets/119358186/856df05a-f650-4ccb-85fa-4f8dae4a1e35">

#### Screenshots of navigator language props in IE, Edge, Chrome and Safari
A screenshot of navigator props in IE:
<img width="923" alt="Screenshot 2023-08-03 at 2 49 56 PM" src="https://github.com/cerner/terra-application/assets/119358186/59b63d1d-0a08-43ed-9fde-270aab43e091">

A screenshot of multiple languages with German being primary language logged for Edge:
<img width="1647" alt="Screenshot 2023-08-03 at 3 03 06 PM" src="https://github.com/cerner/terra-application/assets/119358186/16827c3d-1eb8-4d50-9d33-b9ce3e35d5ba">

A screenshot of German as an only language logged for Chrome:
<img width="1721" alt="Screenshot 2023-08-03 at 3 09 14 PM" src="https://github.com/cerner/terra-application/assets/119358186/8aad1675-a7a6-48ca-845a-46d33fbf1ed6">

A screenshot of Ukrainian as an only language in Safari:
<img width="1180" alt="Знімок екрана 2023-08-03 о 3 42 49 пп" src="https://github.com/cerner/terra-application/assets/119358186/bb59587d-2e17-48e2-8e83-6838cdc3708e">

### Additional Details
**This PR resolves:**

UXPLATFORM-7942
