### PR TITLE
jest.mock replaced with spyOn

### DIFF
--- a/packages/terra-application/CHANGELOG.md
+++ b/packages/terra-application/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changed
   * Updated jest snapshots for terra-icon and terra-button changes.
   * Updated size explanations for ModalManager managed by DisclosureManagerContext.
-  * Updated `uuid` to `8.2.0` for consistency with other components.
+  * Locked `uuid` dependency to `3.4.0`.
 
 * Added
   * Added user action utility button.

--- a/packages/terra-application/package.json
+++ b/packages/terra-application/package.json
@@ -79,7 +79,7 @@
     "terra-theme-provider": "^4.0.0",
     "terra-toolbar": "^1.22.0",
     "terra-visually-hidden-text": "^2.31.0",
-    "uuid": "8.2.0",
+    "uuid": "3.4.0",
     "wicg-inert": "3.1.2"
   },
   "devDependencies": {

--- a/packages/terra-application/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
+++ b/packages/terra-application/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
@@ -20,7 +20,8 @@ const defaultProps = {
 };
 
 const ApplicationLoadingOverlay = ({ isOpen, backgroundStyle }) => {
-  const idRef = useRef(uuidv4());
+  const uuid = uuidv4();
+  const idRef = useRef(uuid);
   const applicationLoadingOverlay = useContext(ApplicationLoadingOverlayContext);
 
   useLayoutEffect(() => {

--- a/packages/terra-application/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
+++ b/packages/terra-application/src/application-loading-overlay/ApplicationLoadingOverlay.jsx
@@ -20,8 +20,7 @@ const defaultProps = {
 };
 
 const ApplicationLoadingOverlay = ({ isOpen, backgroundStyle }) => {
-  const uuid = uuidv4();
-  const idRef = useRef(uuid);
+  const idRef = useRef(uuidv4());
   const applicationLoadingOverlay = useContext(ApplicationLoadingOverlayContext);
 
   useLayoutEffect(() => {

--- a/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
@@ -3,8 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationLoadingOverlay from '../../../src/application-loading-overlay/ApplicationLoadingOverlay';
 
-const mockUuid = '00000000-0000-0000-0000-000000000000';
-
 describe('ApplicationLoadingOverlay', () => {
   let mockSpyUuid;
   let mockSpyContext;
@@ -15,7 +13,7 @@ describe('ApplicationLoadingOverlay', () => {
 
   beforeAll(() => {
     mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(loadingOverlayContextValue);
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(mockUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
   });
 
   afterAll(() => {
@@ -46,13 +44,13 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should transition from open to closed', () => {
@@ -63,14 +61,14 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ isOpen: false });
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(2);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should redisplay loading overlay with new props', () => {
@@ -81,15 +79,15 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ backgroundStyle: 'dark' });
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(2);
-    expect(loadingOverlayContextValue.show.mock.calls[1][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.show.mock.calls[1][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should honor backgroundStyle prop', () => {

--- a/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
@@ -2,40 +2,27 @@ import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationLoadingOverlay from '../../../src/application-loading-overlay/ApplicationLoadingOverlay';
-import ApplicationLoadingOverlayContext from '../../../src/application-loading-overlay/ApplicationLoadingOverlayContext';
-
-jest.mock('uuid');
 
 describe('ApplicationLoadingOverlay', () => {
-  let reactUseContext;
-  let loadingOverlayContextValue;
+  let mockSpyUuid;
+  let mockSpyContext;
+  const mockUuid = '00000000-0000-0000-0000-000000000000';
+  const loadingOverlayContextValue = {
+    show: jest.fn(),
+    hide: jest.fn(),
+  };
 
   beforeAll(() => {
-    uuidv4.mockReturnValue('test-id');
-
-    /**
-     * Until Enzyme is updated with full support for hooks, we need to
-     * mock out the useContext implementation.
-     */
-    reactUseContext = React.useContext;
-    React.useContext = (contextValue) => {
-      if (ApplicationLoadingOverlayContext === contextValue) {
-        return loadingOverlayContextValue;
-      }
-      return reactUseContext(contextValue);
-    };
+    mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(loadingOverlayContextValue);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => mockUuid);
   });
 
   afterAll(() => {
-    React.useContext = reactUseContext;
+    mockSpyContext.mockRestore();
+    mockSpyUuid.mockRestore();
   });
 
   it('should render loading overlay as closed', () => {
-    loadingOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
-
     const wrapper = mount(
       <ApplicationLoadingOverlay />,
     );
@@ -51,11 +38,6 @@ describe('ApplicationLoadingOverlay', () => {
   });
 
   it('should render loading overlay as open', () => {
-    loadingOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
-
     const wrapper = mount(
       <ApplicationLoadingOverlay isOpen />,
     );
@@ -63,21 +45,16 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should transition from open to closed', () => {
-    loadingOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
-
     const wrapper = mount(
       <ApplicationLoadingOverlay isOpen />,
     );
@@ -85,22 +62,17 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ isOpen: false });
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(2);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should redisplay loading overlay with new props', () => {
-    loadingOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
-
     const wrapper = mount(
       <ApplicationLoadingOverlay isOpen />,
     );
@@ -108,23 +80,18 @@ describe('ApplicationLoadingOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ backgroundStyle: 'dark' });
 
     expect(loadingOverlayContextValue.show.mock.calls.length).toBe(2);
-    expect(loadingOverlayContextValue.show.mock.calls[1][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.show.mock.calls[1][0]).toBe(mockUuid);
     expect(loadingOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(loadingOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should honor backgroundStyle prop', () => {
-    loadingOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
-
     const wrapper = mount(
       <ApplicationLoadingOverlay isOpen backgroundStyle="clear" />,
     );

--- a/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-loading-overlay/ApplicationLoadingOverlay.test.jsx
@@ -3,10 +3,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationLoadingOverlay from '../../../src/application-loading-overlay/ApplicationLoadingOverlay';
 
+const mockUuid = '00000000-0000-0000-0000-000000000000';
+
 describe('ApplicationLoadingOverlay', () => {
   let mockSpyUuid;
   let mockSpyContext;
-  const mockUuid = '00000000-0000-0000-0000-000000000000';
   const loadingOverlayContextValue = {
     show: jest.fn(),
     hide: jest.fn(),
@@ -14,7 +15,7 @@ describe('ApplicationLoadingOverlay', () => {
 
   beforeAll(() => {
     mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(loadingOverlayContextValue);
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => mockUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(mockUuid);
   });
 
   afterAll(() => {

--- a/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
@@ -3,8 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationStatusOverlay from '../../../src/application-status-overlay/ApplicationStatusOverlay';
 
-const mockUuid = '00000000-0000-0000-0000-000000000000';
-
 describe('ApplicationStatusOverlay', () => {
   let mockSpyUuid;
   let mockSpyContext;
@@ -15,7 +13,7 @@ describe('ApplicationStatusOverlay', () => {
 
   beforeAll(() => {
     mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(statusOverlayContextValue);
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(mockUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
   });
 
   afterAll(() => {
@@ -31,14 +29,14 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should render status view with the specified data', () => {
@@ -63,14 +61,14 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should redisplay status view with new props', () => {
@@ -81,20 +79,20 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ message: 'No data status view', variant: 'no-data' });
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(2);
-    expect(statusOverlayContextValue.show.mock.calls[1][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.show.mock.calls[1][0]).toBe('00000000-0000-0000-0000-000000000000');
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(2);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('00000000-0000-0000-0000-000000000000');
   });
 
   it('should honor buttonAttrs prop', () => {

--- a/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
@@ -3,10 +3,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationStatusOverlay from '../../../src/application-status-overlay/ApplicationStatusOverlay';
 
+const mockUuid = '00000000-0000-0000-0000-000000000000';
+
 describe('ApplicationStatusOverlay', () => {
   let mockSpyUuid;
   let mockSpyContext;
-  const mockUuid = '00000000-0000-0000-0000-000000000000';
   const statusOverlayContextValue = {
     show: jest.fn(),
     hide: jest.fn(),
@@ -14,7 +15,7 @@ describe('ApplicationStatusOverlay', () => {
 
   beforeAll(() => {
     mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(statusOverlayContextValue);
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => mockUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(mockUuid);
   });
 
   afterAll(() => {

--- a/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
+++ b/packages/terra-application/tests/jest/application-status-overlay/ApplicationStatusOverlay.test.jsx
@@ -2,39 +2,24 @@ import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import ApplicationStatusOverlay from '../../../src/application-status-overlay/ApplicationStatusOverlay';
-import ApplicationStatusOverlayContext from '../../../src/application-status-overlay/ApplicationStatusOverlayContext';
-
-jest.mock('uuid');
 
 describe('ApplicationStatusOverlay', () => {
-  let reactUseContext;
-  let statusOverlayContextValue;
+  let mockSpyUuid;
+  let mockSpyContext;
+  const mockUuid = '00000000-0000-0000-0000-000000000000';
+  const statusOverlayContextValue = {
+    show: jest.fn(),
+    hide: jest.fn(),
+  };
 
   beforeAll(() => {
-    uuidv4.mockReturnValue('test-id');
-
-    /**
-     * Until Enzyme is updated with full support for hooks, we need to
-     * mock out the useContext implementation.
-     */
-    reactUseContext = React.useContext;
-    React.useContext = (contextValue) => {
-      if (contextValue === ApplicationStatusOverlayContext) {
-        return statusOverlayContextValue;
-      }
-      return reactUseContext(contextValue);
-    };
+    mockSpyContext = jest.spyOn(React, 'useContext').mockReturnValue(statusOverlayContextValue);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => mockUuid);
   });
 
   afterAll(() => {
-    React.useContext = reactUseContext;
-  });
-
-  beforeEach(() => {
-    statusOverlayContextValue = {
-      show: jest.fn(),
-      hide: jest.fn(),
-    };
+    mockSpyContext.mockRestore();
+    mockSpyUuid.mockRestore();
   });
 
   it('should render status view without any data', () => {
@@ -45,14 +30,14 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should render status view with the specified data', () => {
@@ -77,14 +62,14 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should redisplay status view with new props', () => {
@@ -95,20 +80,20 @@ describe('ApplicationStatusOverlay', () => {
     expect(wrapper).toMatchSnapshot();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.show.mock.calls[0][0]).toBe(mockUuid);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.setProps({ message: 'No data status view', variant: 'no-data' });
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(2);
-    expect(statusOverlayContextValue.show.mock.calls[1][0]).toBe('test-id');
+    expect(statusOverlayContextValue.show.mock.calls[1][0]).toBe(mockUuid);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(0);
 
     wrapper.unmount();
 
     expect(statusOverlayContextValue.show.mock.calls.length).toBe(2);
     expect(statusOverlayContextValue.hide.mock.calls.length).toBe(1);
-    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe('test-id');
+    expect(statusOverlayContextValue.hide.mock.calls[0][0]).toBe(mockUuid);
   });
 
   it('should honor buttonAttrs prop', () => {

--- a/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
+++ b/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
@@ -1,12 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as ScrollPersistence from '../../../../src/utils/scroll-persistence/scroll-persistence';
 
-const testUuid = '00000000-0000-0000-0000-000000000000';
-
 describe('getOverflowDataForElement', () => {
   let mockSpyUuid;
   beforeAll(() => {
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(testUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue('00000000-0000-0000-0000-000000000000');
   });
 
   afterAll(() => {
@@ -23,9 +21,9 @@ describe('getOverflowDataForElement', () => {
 
     const result = ScrollPersistence.getOverflowDataForElement(mockElement);
 
-    expect(mockElement.setAttribute).toHaveBeenCalledWith('data-persistent-overflow-id', testUuid);
-    expect(result[testUuid].scrollTop).toBe(15);
-    expect(result[testUuid].scrollLeft).toBe(20);
+    expect(mockElement.setAttribute).toHaveBeenCalledWith('data-persistent-overflow-id', '00000000-0000-0000-0000-000000000000');
+    expect(result['00000000-0000-0000-0000-000000000000'].scrollTop).toBe(15);
+    expect(result['00000000-0000-0000-0000-000000000000'].scrollLeft).toBe(20);
   });
 
   test('should not apply overflow-id if one  exists on element', () => {

--- a/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
+++ b/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
@@ -1,8 +1,17 @@
+import { v4 as uuidv4 } from 'uuid';
 import * as ScrollPersistence from '../../../../src/utils/scroll-persistence/scroll-persistence';
 
-jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
-
 describe('getOverflowDataForElement', () => {
+  let mockSpyUuid;
+  const testUuid = '00000000-0000-0000-0000-000000000000';
+  beforeAll(() => {
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => testUuid);
+  });
+
+  afterAll(() => {
+    mockSpyUuid.mockRestore();
+  });
+
   test('should apply overflow-id if none exists on element', () => {
     const mockElement = {
       getAttribute: () => undefined,
@@ -13,9 +22,9 @@ describe('getOverflowDataForElement', () => {
 
     const result = ScrollPersistence.getOverflowDataForElement(mockElement);
 
-    expect(mockElement.setAttribute).toHaveBeenCalledWith('data-persistent-overflow-id', 'test-uuid');
-    expect(result['test-uuid'].scrollTop).toBe(15);
-    expect(result['test-uuid'].scrollLeft).toBe(20);
+    expect(mockElement.setAttribute).toHaveBeenCalledWith('data-persistent-overflow-id', testUuid);
+    expect(result[testUuid].scrollTop).toBe(15);
+    expect(result[testUuid].scrollLeft).toBe(20);
   });
 
   test('should not apply overflow-id if one  exists on element', () => {

--- a/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
+++ b/packages/terra-application/tests/jest/utils/scroll-persistence/scroll-persistence.test.js
@@ -1,11 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import * as ScrollPersistence from '../../../../src/utils/scroll-persistence/scroll-persistence';
 
+const testUuid = '00000000-0000-0000-0000-000000000000';
+
 describe('getOverflowDataForElement', () => {
   let mockSpyUuid;
-  const testUuid = '00000000-0000-0000-0000-000000000000';
   beforeAll(() => {
-    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockImplementation(() => testUuid);
+    mockSpyUuid = jest.spyOn(uuidv4, 'v4').mockReturnValue(testUuid);
   });
 
   afterAll(() => {

--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Changed
   * Updated jest snapshot for terra-icon and terra-button changes.
   * Updated wdio snapshot to fix build.
-  * Updated `uuid` to `8.2.0` for consistency with other components.
+  * Locked `uuid` dependency to `3.4.0`.
 
 ## 8.1.0 - (June 22, 2022)
 

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -83,7 +83,7 @@
     "terra-mixins": "^1.33.0",
     "terra-search-field": "^3.13.0",
     "terra-status-view": "^4.10.0",
-    "uuid": "8.2.0"
+    "uuid": "3.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.5",


### PR DESCRIPTION
### Summary
Currently the uuid test mocks are hard coded. In order to ensures that every test is fresh and independent of each other, the proposed solution was to use beforeAll() to set up the mock. As jest.mock can't be used inside of the tests or inside beforeAll, jest.spyOn was used instead of jest.mock.

**What was changed:**
Hard-coded jest.mock were replaced with jest.spyOn inside the beforeAll().
The mocks were restored in afterAll().
The testing section in documentation was updated to reflect the suggested testing method.

### Testing
This change was tested using:

- [x] WDIO
- [x] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

**This PR is a part of following JIRA:**
UXPLATFORM-9515