### PR TITLE
locale for IE fix

### DIFF
--- a/src/application-base/private/getBrowserLocale.js
+++ b/src/application-base/private/getBrowserLocale.js
@@ -45,6 +45,11 @@ const getBrowserLocale = () => {
     return preferredLocale;
   }
 
+  /* for IE support, as languages and language in IE return undefined, and userLanguage and browserLanguage return "en-US" */
+  if (isSupported(navigator.systemLanguage)) {
+    return navigator.systemLanguage;
+  }
+
   if (isSupported(navigator.language)) {
     return navigator.language;
   }


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
It has been reported that IE does not recognize browser localee. The problem was reported in the smartoze-js repo. That project uses the terra-application version coming from the last commit of **application-v2-integration** branch:
https://github.cerner.com/smartzone/smartzone-js/blob/03f52f0b89c46d1ef71b5bc2ed2940927bdef535/package.json#L86

In order to test the fix for IE browser locale with smartzone-js project the change was made and needs to be merged in this branch.

### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [x] Other (please describe below)
- [ ] No tests are needed

The change was tested with IE browsers locally, the results of the testing was documented in UXPLATFORM-7942. This change is needed to test the change with the actual project the issue was observed. 

### Reviews

In addition to engineering reviews, this PR needs:
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-7942
