### PR TITLE
[terra-dev-site] Fix compile error - lock acorn package to v8.10.0

### DIFF
--- a/packages/terra-dev-site/CHANGELOG.md
+++ b/packages/terra-dev-site/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixes
+  * Locked acorn to v8.10.0 to fix compile error
+  
 ## 7.11.0 - (September 19, 2023)
 
 * Changed

--- a/packages/terra-dev-site/package.json
+++ b/packages/terra-dev-site/package.json
@@ -50,6 +50,7 @@
     "@mdx-js/loader": "^1.4.5",
     "@mdx-js/mdx": "^1.5.0",
     "@mdx-js/react": "^1.4.5",
+    "acorn": "8.10.0",
     "chalk": "^4.1.0",
     "classnames": "^2.2.5",
     "enhanced-resolve": "^4.1.0 || ^5.4.0",


### PR DESCRIPTION
<!-- 
PLEASE COMPLETE THESE STEPS BEFORE PUBLISHING THE PULL REQUEST:

*Before publishing*
1. Update the title as: [component] changes to component (ex. [terra-button] Added terra-button accessibility guide).
2. Fill out the fields below.
3. Assign yourself to the PR.
4. Add the appropriate package name labels.
5. Add your name to the CONTRIBUTORS.md file. Adding your name to the CONTRIBUTORS.md file signifies agreement to all rights and reservations provided by the License.
-->

### Summary
<!--- Summarize and explain the reasoning behind these code changes. What are the changes, and why are they necessary? -->

**What was changed:**
Fix compile error by locking acorn package to v8.10.0 

**Why it was changed:**
Saw compile error and failing builds due to package update for acorn from v8.10.0 to v8.11.0 or v8.11.1. 


### Testing
<!-- Demonstrate that these changes are stable. How have these changes been verified? -->
Before : 
![image](https://github.com/cerner/terra-application/assets/19804033/382e4e92-a649-43f2-b997-79f2c4c570db)

After: 
![image](https://github.com/cerner/terra-application/assets/19804033/dd0e3421-5ef8-4f4e-a853-c519ad30e935)

This change was tested using:

- [ ] WDIO
- [ ] Jest
- [ ] Visual testing (please attach a screenshot or recording)
- [ ] Other (please describe below)
- [ ] No tests are needed

### Reviews

In addition to engineering reviews, this PR needs:
<!-- Please include the appropriate "Required" & "Ready" labels (ex. "UX Review Required" and "UX Review Ready").  -->
- [ ] UX review
- [ ] Accessibility review
- [ ] Functional review

### Additional Details
<!-- List anything else that is relevant to this issue. Additional information will help us better understand your changes and speed up the review process. -->

**This PR resolves:**

UXPLATFORM-XXXX <!-- Jira Number or issue Number. Please do not link to Jira. -->

---

Thank you for contributing to Terra.
@cerner/terra
